### PR TITLE
Network Hardening

### DIFF
--- a/deployments/UnityMixpanel/Assets/Mixpanel/Mixpanel.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/Mixpanel.cs
@@ -1,6 +1,6 @@
 ﻿/*
     *** do not modify the line below, it is updated by the build scripts ***
-    Mixpanel SDK for Unity version 1.0.0
+    Mixpanel SDK for Unity version v1.0.0
 */
 
 #if !UNITY_PRO_LICENSE && (UNITY_2_6||UNITY_2_6_1||UNITY_3_0||UNITY_3_0_0||UNITY_3_1||UNITY_3_2||UNITY_3_3||UNITY_3_4||UNITY_3_5||UNITY_4_0||UNITY_4_0_1||UNITY_4_1||UNITY_4_2||UNITY_4_3||UNITY_4_5||UNITY_4_6)

--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -277,7 +277,7 @@ namespace mixpanel
             LogEntry::Level min_log_level;
             std::queue<LogEntry> log_entries;
             std::mutex log_queue_mutex;
-        
+
             static std::shared_ptr<detail::Worker> worker;
     };
 }

--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -1,6 +1,6 @@
 /*
     *** do not modify the line below, it is updated by the build scripts ***
-    Mixpanel C++ SDK version 1.0.0
+    Mixpanel C++ SDK version v1.0.0
 */
 
 #ifndef _MIXPANEL_HPP_
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <memory>
 #include "./value.hpp"
+#include "../../tests/gtest/include/gtest/gtest_prod.h"
 
 #if defined(_MSC_VER)
 #    pragma warning( disable : 4290 )
@@ -228,6 +229,9 @@ namespace mixpanel
         private:
             friend class People;
             friend class mixpanel::detail::Worker;
+            FRIEND_TEST(MixpanelNetwork, RetryAfter);
+            FRIEND_TEST(MixpanelNetwork, BackOffTime);
+            FRIEND_TEST(MixpanelNetwork, FailureRecovery);
 
             enum Op
             {
@@ -248,10 +252,11 @@ namespace mixpanel
 
             /// iso-format a time in UTC
             static std::string utc_iso_format(time_t time);
-
             static std::time_t utc_now_timestamp();
 
             std::string get_distinct_id() const;
+
+            std::shared_ptr<detail::Worker> worker;
 
             std::string token;
             Value state;

--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -229,9 +229,6 @@ namespace mixpanel
         private:
             friend class People;
             friend class mixpanel::detail::Worker;
-            FRIEND_TEST(MixpanelNetwork, RetryAfter);
-            FRIEND_TEST(MixpanelNetwork, BackOffTime);
-            FRIEND_TEST(MixpanelNetwork, FailureRecovery);
 
             enum Op
             {

--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -20,6 +20,10 @@
 #    pragma warning( disable : 4290 )
 #endif
 
+class MixpanelNetwork_RetryAfter_Test;
+class MixpanelNetwork_BackOffTime_Test;
+class MixpanelNetwork_FailureRecovery_Test;
+
 namespace mixpanel
 {
     namespace detail
@@ -51,7 +55,7 @@ namespace mixpanel
                 /// don't print to std::clog, but queue the log entries for retrieval via get_next_log_entry().
                 /// note that the queue will hold at most 100 entries. So make sure to get_next_log_entry() frequently enough.
                 const bool enable_log_queue = false
-            ) throw(std::logic_error);
+            );
 
             /// construct a Mixpanel instance with custom parameters. This is useful, if you want to modify the defaults
             Mixpanel(
@@ -59,7 +63,7 @@ namespace mixpanel
                 const std::string& distinct_id,        ///< if empty, we're going to get the device id on Android, iOS and OSX and a random UUID on Windows
                 const std::string& storage_directory,  ///< a writable directory to persist the data to
                 const bool enable_log_queue = false    ///< if true, don't print to std::clog, but queue the log entries for retrieval via get_next_log_entry()
-            ) throw(std::logic_error);
+            );
 
             virtual ~Mixpanel();
 
@@ -229,6 +233,9 @@ namespace mixpanel
         private:
             friend class People;
             friend class mixpanel::detail::Worker;
+            FRIEND_TEST(::MixpanelNetwork, RetryAfter);
+            FRIEND_TEST(::MixpanelNetwork, BackOffTime);
+            FRIEND_TEST(::MixpanelNetwork, FailureRecovery);
 
             enum Op
             {
@@ -270,6 +277,8 @@ namespace mixpanel
             LogEntry::Level min_log_level;
             std::queue<LogEntry> log_entries;
             std::mutex log_queue_mutex;
+        
+            static std::shared_ptr<detail::Worker> worker;
     };
 }
 

--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -253,8 +253,6 @@ namespace mixpanel
 
             std::string get_distinct_id() const;
 
-            std::shared_ptr<detail::Worker> worker;
-
             std::string token;
             Value state;
             Value super_properties;

--- a/native/source/dependencies/nano/include/nanowww/nanowww.h
+++ b/native/source/dependencies/nano/include/nanowww/nanowww.h
@@ -152,7 +152,7 @@ namespace nanowww {
             if (iter != headers_.end()) {
                 return iter->second[0];
             }
-            return NULL;
+            return std::string();
         }
         inline std::string as_string() {
             std::string res;

--- a/native/source/dependencies/nano/include/nanowww/nanowww.h
+++ b/native/source/dependencies/nano/include/nanowww/nanowww.h
@@ -148,17 +148,17 @@ namespace nanowww {
         inline void set_header(const char *key, const char *val) {
             this->set_header(key, std::string(val));
         }
-        inline const std::string get_header(const char *key) const {
+        inline std::string get_header(const char *key) const {
             const_iterator iter = headers_.find(key);
             if (iter != headers_.end()) {
                 return iter->second[0];
             }
             return std::string();
         }
-        inline const std::string as_string() const {
+        inline std::string as_string() const {
             std::string res;
-            for ( const_iterator iter = headers_.cbegin(); iter != headers_.cend(); ++iter ) {
-                std::vector<std::string>::const_iterator ci = iter->second.cbegin();
+            for ( const_iterator iter = headers_.begin(); iter != headers_.end(); ++iter ) {
+                std::vector<std::string>::const_iterator ci = iter->second.begin();
                 for (;ci!=iter->second.end(); ++ci) {
                     assert(
                            ci->find('\n') == std::string::npos
@@ -210,7 +210,7 @@ namespace nanowww {
         inline void set_status(int _status) {
             status_ = _status;
         }
-        inline const std::string message() const { return msg_; }
+        inline std::string message() const { return msg_; }
         inline void set_message(const char *str, size_t len) {
             msg_.assign(str, len);
         }
@@ -218,7 +218,7 @@ namespace nanowww {
         inline void push_header(const std::string &key, const std::string &val) {
             hdr_.push_header(key.c_str(), val.c_str());
         }
-        inline const std::string get_header(const char *key) const {
+        inline std::string get_header(const char *key) const {
             return hdr_.get_header(key);
         }
         inline void add_content(const std::string &src) {
@@ -227,7 +227,7 @@ namespace nanowww {
         inline void add_content(const char *src, size_t len) {
             content_.append(src, len);
         }
-        const std::string content() const { return content_; }
+        std::string content() const { return content_; }
     };
 
     class Request {

--- a/native/source/dependencies/nano/include/nanowww/nanowww.h
+++ b/native/source/dependencies/nano/include/nanowww/nanowww.h
@@ -114,6 +114,7 @@ namespace nanowww {
     private:
         std::map< std::string, std::vector<std::string> > headers_;
         typedef std::map< std::string, std::vector<std::string> >::iterator iterator;
+        typedef std::map< std::string, std::vector<std::string> >::const_iterator const_iterator;
     public:
         inline void push_header(const char *key, const char *val) {
             this->push_header(key, std::string(val));
@@ -147,17 +148,17 @@ namespace nanowww {
         inline void set_header(const char *key, const char *val) {
             this->set_header(key, std::string(val));
         }
-        inline std::string get_header(const char *key) {
-            iterator iter = headers_.find(key);
+        inline const std::string get_header(const char *key) const {
+            const_iterator iter = headers_.find(key);
             if (iter != headers_.end()) {
                 return iter->second[0];
             }
             return std::string();
         }
-        inline std::string as_string() {
+        inline const std::string as_string() const {
             std::string res;
-            for ( iterator iter = headers_.begin(); iter != headers_.end(); ++iter ) {
-                std::vector<std::string>::iterator ci = iter->second.begin();
+            for ( const_iterator iter = headers_.cbegin(); iter != headers_.cend(); ++iter ) {
+                std::vector<std::string>::const_iterator ci = iter->second.cbegin();
                 for (;ci!=iter->second.end(); ++ci) {
                     assert(
                            ci->find('\n') == std::string::npos
@@ -205,19 +206,19 @@ namespace nanowww {
         inline bool is_success() {
             return status_ == 200;
         }
-        inline int status() { return status_; }
+        inline int status() const { return status_; }
         inline void set_status(int _status) {
             status_ = _status;
         }
-        inline std::string message() { return msg_; }
+        inline const std::string message() const { return msg_; }
         inline void set_message(const char *str, size_t len) {
             msg_.assign(str, len);
         }
-        inline Headers * headers() { return &hdr_; }
+        inline const Headers * headers() const { return &hdr_; }
         inline void push_header(const std::string &key, const std::string &val) {
             hdr_.push_header(key.c_str(), val.c_str());
         }
-        inline std::string get_header(const char *key) {
+        inline const std::string get_header(const char *key) const {
             return hdr_.get_header(key);
         }
         inline void add_content(const std::string &src) {
@@ -226,7 +227,7 @@ namespace nanowww {
         inline void add_content(const char *src, size_t len) {
             content_.append(src, len);
         }
-        std::string content() { return content_; }
+        const std::string content() const { return content_; }
     };
 
     class Request {

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -32,7 +32,7 @@ namespace mixpanel
     using namespace detail;
 
     static std::chrono::steady_clock::time_point app_start = std::chrono::steady_clock::now();
-    
+
     std::shared_ptr<detail::Worker> Mixpanel::worker;
 
     Mixpanel::Mixpanel(
@@ -57,10 +57,10 @@ namespace mixpanel
         {
             throw std::logic_error("Only one Mixpanel instance at a time is supported.");
         }
-        
+
         if (token.size() < 8)
         {
-            throw std::invalid_argument("You must provide a valid Mixpanel token");
+            throw std::invalid_argument("You must provide a valid Mixpanel token.");
         }
 
         Persistence::set_storage_directory(storage_directory);

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -19,7 +19,7 @@
 
 namespace mixpanel
 {
-    static const std::string sdk_version = "1.0.0";
+    static const std::string sdk_version = "v1.0.0";
 
     // helper function to get the time since epoch as double / float etc.
     template <typename T>
@@ -32,8 +32,6 @@ namespace mixpanel
     using namespace detail;
 
     static std::chrono::steady_clock::time_point app_start = std::chrono::steady_clock::now();
-
-    std::shared_ptr<detail::Worker> worker;
 
     Mixpanel::Mixpanel(
         const std::string& token,
@@ -53,11 +51,6 @@ namespace mixpanel
         ,min_log_level(LogEntry::LL_WARNING)
 #endif
     {
-        if (worker)
-        {
-            throw std::logic_error("Only one Mixpanel instance is allowed at any time");
-        }
-
         if (token.size() < 8)
         {
             throw std::invalid_argument("You must provide a valid mixpanel token");
@@ -110,7 +103,11 @@ namespace mixpanel
 
     void Mixpanel::log(LogEntry::Level level, const std::string& message)
     {
-        assert(level == LogEntry::LL_TRACE || level == LogEntry::LL_DEBUG || level == LogEntry::LL_INFO || level == LogEntry::LL_WARNING || level == LogEntry::LL_ERROR);
+        assert(level == LogEntry::LL_TRACE      ||
+               level == LogEntry::LL_DEBUG      ||
+               level == LogEntry::LL_INFO       ||
+               level == LogEntry::LL_WARNING    ||
+               level == LogEntry::LL_ERROR);
 
         if (level < min_log_level) return;
 

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -33,14 +33,14 @@ namespace mixpanel
 
     static std::chrono::steady_clock::time_point app_start = std::chrono::steady_clock::now();
     
-    std::shared_ptr<detail::Worker> worker;
+    std::shared_ptr<detail::Worker> Mixpanel::worker;
 
     Mixpanel::Mixpanel(
         const std::string& token,
         const std::string& distinct_id,
         const std::string& storage_directory,
         const bool enable_log_queue
-    ) throw(std::logic_error)
+    )
         :people(this)
         ,token(token)
         ,automatic_properties(collect_automatic_properties())
@@ -93,7 +93,7 @@ namespace mixpanel
     Mixpanel::Mixpanel(
         const std::string& token,
         const bool enable_log_queue
-    ) throw(std::logic_error)
+    )
         :Mixpanel(
             token,
             "", // the other constructor will take care of that

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -32,6 +32,8 @@ namespace mixpanel
     using namespace detail;
 
     static std::chrono::steady_clock::time_point app_start = std::chrono::steady_clock::now();
+    
+    std::shared_ptr<detail::Worker> worker;
 
     Mixpanel::Mixpanel(
         const std::string& token,
@@ -51,9 +53,14 @@ namespace mixpanel
         ,min_log_level(LogEntry::LL_WARNING)
 #endif
     {
+        if (worker)
+        {
+            throw std::logic_error("Only one Mixpanel instance at a time is supported.");
+        }
+        
         if (token.size() < 8)
         {
-            throw std::invalid_argument("You must provide a valid mixpanel token");
+            throw std::invalid_argument("You must provide a valid Mixpanel token");
         }
 
         Persistence::set_storage_directory(storage_directory);

--- a/native/source/mixpanel/detail/worker.cpp
+++ b/native/source/mixpanel/detail/worker.cpp
@@ -196,7 +196,7 @@ namespace mixpanel
             }
         }
 
-        int Worker::parse_www_retry_after(nanowww::Response& response)
+        int Worker::parse_www_retry_after(const nanowww::Response& response)
         {
             mixpanel->log(Mixpanel::LogEntry::LL_TRACE, "/track HTTP Response Headers: \n" + response.headers()->as_string());
             mixpanel->log(Mixpanel::LogEntry::LL_TRACE, "/track HTTP Response Body: \n" + response.content());

--- a/native/source/mixpanel/detail/worker.cpp
+++ b/native/source/mixpanel/detail/worker.cpp
@@ -53,6 +53,7 @@ namespace mixpanel
         {
             delivery_failure_flag = false;
             network_requests_allowed_time = time(0);
+            failure_count = 0;
 
             assert(mixpanel);
             mixpanel->log(Mixpanel::LogEntry::LL_INFO, "starting mixpanel worker");
@@ -198,9 +199,6 @@ namespace mixpanel
 
         int Worker::parse_www_retry_after(nanowww::Response& response)
         {
-            auto success = false;
-            static auto failure_count = 0;
-
             mixpanel->log(Mixpanel::LogEntry::LL_TRACE, "/track HTTP Response Headers: \n" + response.headers()->as_string());
             mixpanel->log(Mixpanel::LogEntry::LL_TRACE, "/track HTTP Response Body: \n" + response.content());
 
@@ -219,7 +217,6 @@ namespace mixpanel
                 mixpanel->log(Mixpanel::LogEntry::LL_ERROR, "/track HTTP Call Failed - Status Code (" + std::to_string(response.status()) + "): " + response.content());
             } else {
                 failure_count = 0;
-                success = true;
             }
 
             // Calculate exponential back off

--- a/native/source/mixpanel/detail/worker.cpp
+++ b/native/source/mixpanel/detail/worker.cpp
@@ -230,7 +230,7 @@ namespace mixpanel
 
             auto allowed_after_time = time(0) + retry_after;
             mixpanel->log(Mixpanel::LogEntry::LL_TRACE, "Network requests allowed after time " + std::to_string(allowed_after_time) +
-                          ". Current time " + std::to_string(time(0)) + ". Delta: " + std::to_string(time(0) - allowed_after_time));
+                          ". Current time " + std::to_string(time(0)) + ". Delta: " + std::to_string(allowed_after_time - time(0)));
             return allowed_after_time;
         }
 

--- a/native/source/mixpanel/detail/worker.cpp
+++ b/native/source/mixpanel/detail/worker.cpp
@@ -29,7 +29,6 @@ namespace mixpanel
         } _wsinit_;
         #endif
 
-
         #ifdef HAVE_MBEDTLS
         const static std::string api_host = "https://api.mixpanel.com/";
         #else

--- a/native/source/mixpanel/detail/worker.hpp
+++ b/native/source/mixpanel/detail/worker.hpp
@@ -51,7 +51,7 @@ namespace mixpanel
                 Result send_engage_batch();
                 Result send_batch(const std::string& name, bool verbose);
 
-                int parse_www_retry_after(nanowww::Response& response);
+                int parse_www_retry_after(const nanowww::Response& response);
                 int calculate_back_off_time(int failure_count);
 
                 Mixpanel* mixpanel;

--- a/native/source/mixpanel/detail/worker.hpp
+++ b/native/source/mixpanel/detail/worker.hpp
@@ -11,6 +11,10 @@
 #include "../../../tests/gtest/include/gtest/gtest_prod.h"
 #include "../../dependencies/nano/include/nanowww/nanowww.h"
 
+class MixpanelNetwork_RetryAfter_Test;
+class MixpanelNetwork_BackOffTime_Test;
+class MixpanelNetwork_FailureRecovery_Test;
+
 namespace mixpanel
 {
     class Mixpanel;
@@ -30,9 +34,9 @@ namespace mixpanel
                 void flush_queue();
                 void clear_send_queues();
             private:
-                FRIEND_TEST(MixpanelNetwork, RetryAfter);
-                FRIEND_TEST(MixpanelNetwork, BackOffTime);
-                FRIEND_TEST(MixpanelNetwork, FailureRecovery);
+                FRIEND_TEST(::MixpanelNetwork, RetryAfter);
+                FRIEND_TEST(::MixpanelNetwork, BackOffTime);
+                FRIEND_TEST(::MixpanelNetwork, FailureRecovery);
 
                 void main();
 

--- a/native/source/mixpanel/detail/worker.hpp
+++ b/native/source/mixpanel/detail/worker.hpp
@@ -58,6 +58,7 @@ namespace mixpanel
                 std::atomic<bool> thread_should_exit;
                 std::atomic<bool> new_data;
                 std::atomic<bool> should_flush_queue;
+                std::atomic<int> failure_count;
                 std::atomic<unsigned> flush_interval;
                 std::atomic<time_t> network_requests_allowed_time;
                 std::thread send_thread;

--- a/native/source/mixpanel/detail/worker.hpp
+++ b/native/source/mixpanel/detail/worker.hpp
@@ -52,7 +52,7 @@ namespace mixpanel
                 Result send_batch(const std::string& name, bool verbose);
 
                 int parse_www_retry_after(const nanowww::Response& response);
-                int calculate_back_off_time(int failure_count);
+                static int calculate_back_off_time(int failure_count);
 
                 Mixpanel* mixpanel;
                 std::atomic<bool> thread_should_exit;

--- a/native/tests/src/test_config.hpp
+++ b/native/tests/src/test_config.hpp
@@ -5,7 +5,7 @@
 
 namespace
 {
-    static const std::string mp_token      = "f0b8be9951601e68d936b1ce40dfdf39";
+    static const std::string mp_token      = "c530a1e90cfe01783793dab2bf1580b5";
 }
 
 #endif //MIXPANEL_TEST_CONFIG_HPP

--- a/native/tests/src/test_main.cpp
+++ b/native/tests/src/test_main.cpp
@@ -4,9 +4,5 @@
 
 GTEST_API_ int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
-  ::testing::TestEventListeners& listeners =
-      ::testing::UnitTest::GetInstance()->listeners();
-  // Adds a listener to the end.  Google Test takes the ownership.
-  //listeners.Append(new WebReportTestEventListener());
   return RUN_ALL_TESTS();
 }

--- a/native/tests/src/test_multiple_instances.cpp
+++ b/native/tests/src/test_multiple_instances.cpp
@@ -4,7 +4,7 @@
 #include <mixpanel/detail/workarounds.hpp>
 #include "test_config.hpp"
 
-TEST(Mixpanel, MultpleInstances)
+TEST(Mixpanel, MultipleInstances)
 {
     using namespace mixpanel;
 
@@ -18,7 +18,6 @@ TEST(Mixpanel, MultpleInstances)
 
     {
         std::shared_ptr<mixpanel::Mixpanel> instance1, instance2, instance3;
-
         ASSERT_NO_THROW(instance1 = std::make_shared<Mixpanel>("123456789"));
         ASSERT_THROW(instance2 = std::make_shared<Mixpanel>("123456789"), std::logic_error);
         ASSERT_THROW(instance3 = std::make_shared<Mixpanel>("123456789"), std::logic_error);

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -13,10 +13,10 @@ TEST(MixpanelNetwork, RetryAfter)
 {
     Mixpanel mp(mp_token);
     auto worker = Mixpanel::worker;
-    
+
     nanowww::Response retry_after_response;
     retry_after_response.push_header("Retry-After", "51");
-    
+
     auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
     auto back_off_duration = retry_after_time - time(0);
     ASSERT_EQ(back_off_duration, 51);
@@ -79,10 +79,8 @@ TEST(MixpanelNetwork, FailureRecovery)
 
     auto retry_after_time = worker->parse_www_retry_after(success_response);
     ASSERT_EQ(worker->failure_count, 0);
-    
+
     auto back_off_duration = retry_after_time - time(0);
     // Back off time should be reset
     ASSERT_EQ(back_off_duration, 0);
 }
-
-

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -1,86 +1,86 @@
-#include <gtest/gtest.h>
-#include <mixpanel/mixpanel.hpp>
-#include <mixpanel/detail/worker.hpp>
-#include "../../source/dependencies/nano/include/nanowww/nanowww.h"
-#include "test_config.hpp"
-
+//#include <gtest/gtest.h>
+//#include <mixpanel/mixpanel.hpp>
+//#include <mixpanel/detail/worker.hpp>
+//#include "../../source/dependencies/nano/include/nanowww/nanowww.h"
+//#include "test_config.hpp"
 //
-// Ensure "Retry-After" HTTP header is respected
+////
+//// Ensure "Retry-After" HTTP header is respected
+////
+//TEST(MixpanelNetwork, RetryAfter)
+//{
+//    mixpanel::Mixpanel mp(mp_token);
+//    auto worker = mixpanel::detail::worker;
+//    
+//    nanowww::Response retry_after_response;
+//    retry_after_response.push_header("Retry-After", "51");
+//    
+//    auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
+//    auto back_off_duration = retry_after_time - time(0);
+//    ASSERT_EQ(back_off_duration, 51);
+//    ASSERT_EQ(worker->failure_count, 0);
+//}
 //
-TEST(MixpanelNetwork, RetryAfter)
-{
-    mixpanel::Mixpanel mp(mp_token);
-    auto worker = mixpanel::detail::worker;
-    
-    nanowww::Response retry_after_response;
-    retry_after_response.push_header("Retry-After", "51");
-    
-    auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
-    auto back_off_duration = retry_after_time - time(0);
-    ASSERT_EQ(back_off_duration, 51);
-    ASSERT_EQ(worker->failure_count, 0);
-}
-
+////
+//// Ensure successive failures result in an exponential back
+////      off time.
+////
+//TEST(MixpanelNetwork, BackOffTime)
+//{
+//    mixpanel::Mixpanel mp(mp_token);
+//    auto worker = mixpanel::detail::worker;
 //
-// Ensure successive failures result in an exponential back
-//      off time.
+//    nanowww::Response failure_response;
+//    failure_response.set_status(503);
 //
-TEST(MixpanelNetwork, BackOffTime)
-{
-    mixpanel::Mixpanel mp(mp_token);
-    auto worker = mixpanel::detail::worker;
-
-    nanowww::Response failure_response;
-    failure_response.set_status(503);
-
-    // We need 2 consecutive failures to enable exponential back off
-    worker->parse_www_retry_after(failure_response);
-    ASSERT_EQ(worker->failure_count, 1);
-    auto retry_after_time = worker->parse_www_retry_after(failure_response);
-    ASSERT_EQ(worker->failure_count, 2);
-
-    auto back_off_duration = retry_after_time - time(0);
-    // Should back off randomly between 120 - 150s
-    ASSERT_GT(back_off_duration, 115);
-    ASSERT_LE(back_off_duration, 150);
-
-    // Test a third failure
-    retry_after_time = worker->parse_www_retry_after(failure_response);
-    ASSERT_EQ(worker->failure_count, 3);
-    back_off_duration = retry_after_time - time(0);
-
-    // Should back off randomly between 240 - 270s
-    ASSERT_GT(back_off_duration, 235);
-    ASSERT_LE(back_off_duration, 270);
-}
-
+//    // We need 2 consecutive failures to enable exponential back off
+//    worker->parse_www_retry_after(failure_response);
+//    ASSERT_EQ(worker->failure_count, 1);
+//    auto retry_after_time = worker->parse_www_retry_after(failure_response);
+//    ASSERT_EQ(worker->failure_count, 2);
 //
-// A single success after a number of failures should reset the back off time.
+//    auto back_off_duration = retry_after_time - time(0);
+//    // Should back off randomly between 120 - 150s
+//    ASSERT_GT(back_off_duration, 115);
+//    ASSERT_LE(back_off_duration, 150);
 //
-TEST(MixpanelNetwork, FailureRecovery)
-{
-    mixpanel::Mixpanel mp(mp_token);
-    auto worker = mixpanel::detail::worker;
-
-    nanowww::Response failure_response;
-    failure_response.set_status(503);
-
-    // We need 2 consecutive failures to enable exponential back off
-    worker->parse_www_retry_after(failure_response);
-    ASSERT_EQ(worker->failure_count, 1);
-    worker->parse_www_retry_after(failure_response);
-    ASSERT_EQ(worker->failure_count, 2);
-
-    // Followed by 1 success to reset the back off
-    nanowww::Response success_response;
-    success_response.set_status(200);
-
-    auto retry_after_time = worker->parse_www_retry_after(success_response);
-    ASSERT_EQ(worker->failure_count, 0);
-    
-    auto back_off_duration = retry_after_time - time(0);
-    // Back off time should be reset
-    ASSERT_EQ(back_off_duration, 0);
-}
-
-
+//    // Test a third failure
+//    retry_after_time = worker->parse_www_retry_after(failure_response);
+//    ASSERT_EQ(worker->failure_count, 3);
+//    back_off_duration = retry_after_time - time(0);
+//
+//    // Should back off randomly between 240 - 270s
+//    ASSERT_GT(back_off_duration, 235);
+//    ASSERT_LE(back_off_duration, 270);
+//}
+//
+////
+//// A single success after a number of failures should reset the back off time.
+////
+//TEST(MixpanelNetwork, FailureRecovery)
+//{
+//    mixpanel::Mixpanel mp(mp_token);
+//    auto worker = mixpanel::detail::worker;
+//
+//    nanowww::Response failure_response;
+//    failure_response.set_status(503);
+//
+//    // We need 2 consecutive failures to enable exponential back off
+//    worker->parse_www_retry_after(failure_response);
+//    ASSERT_EQ(worker->failure_count, 1);
+//    worker->parse_www_retry_after(failure_response);
+//    ASSERT_EQ(worker->failure_count, 2);
+//
+//    // Followed by 1 success to reset the back off
+//    nanowww::Response success_response;
+//    success_response.set_status(200);
+//
+//    auto retry_after_time = worker->parse_www_retry_after(success_response);
+//    ASSERT_EQ(worker->failure_count, 0);
+//    
+//    auto back_off_duration = retry_after_time - time(0);
+//    // Back off time should be reset
+//    ASSERT_EQ(back_off_duration, 0);
+//}
+//
+//

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -5,74 +5,74 @@
 #include "test_config.hpp"
 
 //
-// Note: We've placed these tests into the mixpanel namespace so we can access
-//       private members and functions as a friend class. This makes use of
-//       the FRIEND_TEST macro in worker.hpp
+// Ensure "Retry-After" HTTP header is respected
 //
-namespace mixpanel
+TEST(MixpanelNetwork, RetryAfter)
 {
-    namespace detail
-    {
-        // Ensure "Retry-After" HTTP header is respected
-        TEST(MixpanelNetwork, RetryAfter)
-        {
-            auto mp = new mixpanel::Mixpanel(mp_token);
-            auto worker = new mixpanel::detail::Worker(mp);
+    auto mp = new mixpanel::Mixpanel(mp_token);
+    auto worker = new mixpanel::detail::Worker(mp);
 
-            nanowww::Response retry_after_response;
-            retry_after_response.push_header("Retry-After", "51");
+    nanowww::Response retry_after_response;
+    retry_after_response.push_header("Retry-After", "51");
 
-            auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
-            auto back_off_duration = retry_after_time - time(0);
-            ASSERT_EQ(back_off_duration, 51);
-        }
-
-        TEST(MixpanelNetwork, BackOffTime)
-        {
-            auto mp = new mixpanel::Mixpanel(mp_token);
-            auto worker = new mixpanel::detail::Worker(mp);
-
-            nanowww::Response failure_response;
-            failure_response.set_status(503);
-
-            // We need 2 consecutive failures to enable exponential back off
-            worker->parse_www_retry_after(failure_response);
-            auto retry_after_time = worker->parse_www_retry_after(failure_response);
-
-            auto back_off_duration = retry_after_time - time(0);
-            // Should back off randomly between 120 - 150s
-            ASSERT_GT(back_off_duration, 115);
-            ASSERT_LE(back_off_duration, 150);
-
-            // Test a third failure
-            retry_after_time = worker->parse_www_retry_after(failure_response);
-            back_off_duration = retry_after_time - time(0);
-
-            // Should back off randomly between 240 - 270s
-            ASSERT_GT(back_off_duration, 235);
-            ASSERT_LE(back_off_duration, 270);
-        }
-
-        TEST(MixpanelNetwork, FailureRecovery)
-        {
-            auto mp = new mixpanel::Mixpanel(mp_token);
-            auto worker = new mixpanel::detail::Worker(mp);
-
-            nanowww::Response failure_response;
-            failure_response.set_status(503);
-
-            // We need 2 consecutive failures to enable exponential back off
-            worker->parse_www_retry_after(failure_response);
-            worker->parse_www_retry_after(failure_response);
-
-            // Followed by 1 success to reset the back off
-            nanowww::Response success_response;
-            success_response.set_status(200);
-
-            auto retry_after_time = worker->parse_www_retry_after(success_response);
-            auto back_off_duration = retry_after_time - time(0);
-            // Back off time should be reset
-            ASSERT_EQ(back_off_duration, 0);
-        }
-    }
+    auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
+    auto back_off_duration = retry_after_time - time(0);
+    ASSERT_EQ(back_off_duration, 51);
 }
+
+//
+// Ensure successive failures result in an exponential back
+//      off time.
+//
+TEST(MixpanelNetwork, BackOffTime)
+{
+    auto mp = new mixpanel::Mixpanel(mp_token);
+    auto worker = new mixpanel::detail::Worker(mp);
+
+    nanowww::Response failure_response;
+    failure_response.set_status(503);
+
+    // We need 2 consecutive failures to enable exponential back off
+    worker->parse_www_retry_after(failure_response);
+    auto retry_after_time = worker->parse_www_retry_after(failure_response);
+
+    auto back_off_duration = retry_after_time - time(0);
+    // Should back off randomly between 120 - 150s
+    ASSERT_GT(back_off_duration, 115);
+    ASSERT_LE(back_off_duration, 150);
+
+    // Test a third failure
+    retry_after_time = worker->parse_www_retry_after(failure_response);
+    back_off_duration = retry_after_time - time(0);
+
+    // Should back off randomly between 240 - 270s
+    ASSERT_GT(back_off_duration, 235);
+    ASSERT_LE(back_off_duration, 270);
+}
+
+//
+// A single success after a number of failures should reset the back off time.
+//
+TEST(MixpanelNetwork, FailureRecovery)
+{
+    auto mp = new mixpanel::Mixpanel(mp_token);
+    auto worker = new mixpanel::detail::Worker(mp);
+
+    nanowww::Response failure_response;
+    failure_response.set_status(503);
+
+    // We need 2 consecutive failures to enable exponential back off
+    worker->parse_www_retry_after(failure_response);
+    worker->parse_www_retry_after(failure_response);
+
+    // Followed by 1 success to reset the back off
+    nanowww::Response success_response;
+    success_response.set_status(200);
+
+    auto retry_after_time = worker->parse_www_retry_after(success_response);
+    auto back_off_duration = retry_after_time - time(0);
+    // Back off time should be reset
+    ASSERT_EQ(back_off_duration, 0);
+}
+
+

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -1,0 +1,78 @@
+#include <gtest/gtest.h>
+#include <mixpanel/mixpanel.hpp>
+#include <mixpanel/detail/worker.hpp>
+#include "../../source/dependencies/nano/include/nanowww/nanowww.h"
+#include "test_config.hpp"
+
+//
+// Note: We've placed these tests in to the mixpanel namespace so we can access
+//       private members and functions as a friend class. This makes use of
+//       the FRIEND_TEST macro in worker.hpp
+//
+namespace mixpanel
+{
+    namespace detail
+    {
+        // Ensure "Retry-After" HTTP header is respected
+        TEST(MixpanelNetwork, RetryAfter)
+        {
+            auto mp = new mixpanel::Mixpanel(mp_token);
+            auto worker = new mixpanel::detail::Worker(mp);
+
+            nanowww::Response retry_after_response;
+            retry_after_response.push_header("Retry-After", "51");
+
+            auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
+            auto back_off_duration = retry_after_time - time(0);
+            ASSERT_EQ(back_off_duration, 51);
+        }
+
+        TEST(MixpanelNetwork, BackOffTime)
+        {
+            auto mp = new mixpanel::Mixpanel(mp_token);
+            auto worker = new mixpanel::detail::Worker(mp);
+
+            nanowww::Response failure_response;
+            failure_response.set_status(503);
+
+            // We need 2 consecutive failures to enable exponential back off
+            worker->parse_www_retry_after(failure_response);
+            auto retry_after_time = worker->parse_www_retry_after(failure_response);
+
+            auto back_off_duration = retry_after_time - time(0);
+            // Should back off randomly between 120 - 150s
+            ASSERT_GT(back_off_duration, 115);
+            ASSERT_LE(back_off_duration, 150);
+
+            // Test a third failure
+            retry_after_time = worker->parse_www_retry_after(failure_response);
+            back_off_duration = retry_after_time - time(0);
+
+            // Should back off randomly between 240 - 270s
+            ASSERT_GT(back_off_duration, 235);
+            ASSERT_LE(back_off_duration, 270);
+        }
+
+        TEST(MixpanelNetwork, FailureRecovery)
+        {
+            auto mp = new mixpanel::Mixpanel(mp_token);
+            auto worker = new mixpanel::detail::Worker(mp);
+
+            nanowww::Response failure_response;
+            failure_response.set_status(503);
+
+            // We need 2 consecutive failures to enable exponential back off
+            worker->parse_www_retry_after(failure_response);
+            worker->parse_www_retry_after(failure_response);
+
+            // Followed by 1 success to reset the back off
+            nanowww::Response success_response;
+            success_response.set_status(200);
+
+            auto retry_after_time = worker->parse_www_retry_after(success_response);
+            auto back_off_duration = retry_after_time - time(0);
+            // Back off time should be reset
+            ASSERT_EQ(back_off_duration, 0);
+        }
+    }
+}

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -1,86 +1,88 @@
-//#include <gtest/gtest.h>
-//#include <mixpanel/mixpanel.hpp>
-//#include <mixpanel/detail/worker.hpp>
-//#include "../../source/dependencies/nano/include/nanowww/nanowww.h"
-//#include "test_config.hpp"
+#include <gtest/gtest.h>
+#include <mixpanel/mixpanel.hpp>
+#include <mixpanel/detail/worker.hpp>
+#include "../../source/dependencies/nano/include/nanowww/nanowww.h"
+#include "test_config.hpp"
+
+using namespace mixpanel;
+
 //
-////
-//// Ensure "Retry-After" HTTP header is respected
-////
-//TEST(MixpanelNetwork, RetryAfter)
-//{
-//    mixpanel::Mixpanel mp(mp_token);
-//    auto worker = mixpanel::detail::worker;
-//    
-//    nanowww::Response retry_after_response;
-//    retry_after_response.push_header("Retry-After", "51");
-//    
-//    auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
-//    auto back_off_duration = retry_after_time - time(0);
-//    ASSERT_EQ(back_off_duration, 51);
-//    ASSERT_EQ(worker->failure_count, 0);
-//}
+// Ensure "Retry-After" HTTP header is respected
 //
-////
-//// Ensure successive failures result in an exponential back
-////      off time.
-////
-//TEST(MixpanelNetwork, BackOffTime)
-//{
-//    mixpanel::Mixpanel mp(mp_token);
-//    auto worker = mixpanel::detail::worker;
+TEST(MixpanelNetwork, RetryAfter)
+{
+    Mixpanel mp(mp_token);
+    auto worker = Mixpanel::worker;
+    
+    nanowww::Response retry_after_response;
+    retry_after_response.push_header("Retry-After", "51");
+    
+    auto retry_after_time = worker->parse_www_retry_after(retry_after_response);
+    auto back_off_duration = retry_after_time - time(0);
+    ASSERT_EQ(back_off_duration, 51);
+    ASSERT_EQ(worker->failure_count, 0);
+}
+
 //
-//    nanowww::Response failure_response;
-//    failure_response.set_status(503);
+// Ensure successive failures result in an exponential back
+//      off time.
 //
-//    // We need 2 consecutive failures to enable exponential back off
-//    worker->parse_www_retry_after(failure_response);
-//    ASSERT_EQ(worker->failure_count, 1);
-//    auto retry_after_time = worker->parse_www_retry_after(failure_response);
-//    ASSERT_EQ(worker->failure_count, 2);
+TEST(MixpanelNetwork, BackOffTime)
+{
+    Mixpanel mp(mp_token);
+    auto worker = Mixpanel::worker;
+
+    nanowww::Response failure_response;
+    failure_response.set_status(503);
+
+    // We need 2 consecutive failures to enable exponential back off
+    worker->parse_www_retry_after(failure_response);
+    ASSERT_EQ(worker->failure_count, 1);
+    auto retry_after_time = worker->parse_www_retry_after(failure_response);
+    ASSERT_EQ(worker->failure_count, 2);
+
+    auto back_off_duration = retry_after_time - time(0);
+    // Should back off randomly between 120 - 150s
+    ASSERT_GT(back_off_duration, 115);
+    ASSERT_LE(back_off_duration, 150);
+
+    // Test a third failure
+    retry_after_time = worker->parse_www_retry_after(failure_response);
+    ASSERT_EQ(worker->failure_count, 3);
+    back_off_duration = retry_after_time - time(0);
+
+    // Should back off randomly between 240 - 270s
+    ASSERT_GT(back_off_duration, 235);
+    ASSERT_LE(back_off_duration, 270);
+}
+
 //
-//    auto back_off_duration = retry_after_time - time(0);
-//    // Should back off randomly between 120 - 150s
-//    ASSERT_GT(back_off_duration, 115);
-//    ASSERT_LE(back_off_duration, 150);
+// A single success after a number of failures should reset the back off time.
 //
-//    // Test a third failure
-//    retry_after_time = worker->parse_www_retry_after(failure_response);
-//    ASSERT_EQ(worker->failure_count, 3);
-//    back_off_duration = retry_after_time - time(0);
-//
-//    // Should back off randomly between 240 - 270s
-//    ASSERT_GT(back_off_duration, 235);
-//    ASSERT_LE(back_off_duration, 270);
-//}
-//
-////
-//// A single success after a number of failures should reset the back off time.
-////
-//TEST(MixpanelNetwork, FailureRecovery)
-//{
-//    mixpanel::Mixpanel mp(mp_token);
-//    auto worker = mixpanel::detail::worker;
-//
-//    nanowww::Response failure_response;
-//    failure_response.set_status(503);
-//
-//    // We need 2 consecutive failures to enable exponential back off
-//    worker->parse_www_retry_after(failure_response);
-//    ASSERT_EQ(worker->failure_count, 1);
-//    worker->parse_www_retry_after(failure_response);
-//    ASSERT_EQ(worker->failure_count, 2);
-//
-//    // Followed by 1 success to reset the back off
-//    nanowww::Response success_response;
-//    success_response.set_status(200);
-//
-//    auto retry_after_time = worker->parse_www_retry_after(success_response);
-//    ASSERT_EQ(worker->failure_count, 0);
-//    
-//    auto back_off_duration = retry_after_time - time(0);
-//    // Back off time should be reset
-//    ASSERT_EQ(back_off_duration, 0);
-//}
-//
-//
+TEST(MixpanelNetwork, FailureRecovery)
+{
+    Mixpanel mp(mp_token);
+    auto worker = Mixpanel::worker;
+
+    nanowww::Response failure_response;
+    failure_response.set_status(503);
+
+    // We need 2 consecutive failures to enable exponential back off
+    worker->parse_www_retry_after(failure_response);
+    ASSERT_EQ(worker->failure_count, 1);
+    worker->parse_www_retry_after(failure_response);
+    ASSERT_EQ(worker->failure_count, 2);
+
+    // Followed by 1 success to reset the back off
+    nanowww::Response success_response;
+    success_response.set_status(200);
+
+    auto retry_after_time = worker->parse_www_retry_after(success_response);
+    ASSERT_EQ(worker->failure_count, 0);
+    
+    auto back_off_duration = retry_after_time - time(0);
+    // Back off time should be reset
+    ASSERT_EQ(back_off_duration, 0);
+}
+
+

--- a/native/tests/src/test_network.cpp
+++ b/native/tests/src/test_network.cpp
@@ -5,7 +5,7 @@
 #include "test_config.hpp"
 
 //
-// Note: We've placed these tests in to the mixpanel namespace so we can access
+// Note: We've placed these tests into the mixpanel namespace so we can access
 //       private members and functions as a friend class. This makes use of
 //       the FRIEND_TEST macro in worker.hpp
 //


### PR DESCRIPTION
- [X] Respects `Retry-After` HTTP header
- [X] Resolved a bug in [nanowww](https://github.com/tokuhirom/nanowww/pull/1) where `NULL` was incorrectly being returned.
- [X] Added Tests: `RetryAfter`, `BackOffTime`, `FailureRecovery`