### PR TITLE
Some cosmetic cleanup suggested by cpplint.

### DIFF
--- a/native/source/mixpanel/detail/base64.cpp
+++ b/native/source/mixpanel/detail/base64.cpp
@@ -1,5 +1,6 @@
 #include "base64.hpp"
 #include <iostream>
+#include <string>
 
 /*
  * based upon http://www.adp-gmbh.ch/cpp/common/base64.html
@@ -84,11 +85,9 @@ namespace mixpanel
 
             while((i++ < 3))
               ret += '=';
-
           }
 
           return ret;
-
         }
 
 
@@ -96,5 +95,5 @@ namespace mixpanel
         {
             return base64_encode(reinterpret_cast<const unsigned char*>(s.data()), s.size());
         }
-    }
-}
+    } // namespace detail
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -1,10 +1,13 @@
-#include <string>
+#include <chrono>
+#include <cmath>
+#include <ctime>
 #include <iomanip>
 #include <iostream>
-#include <ctime>
+#include <string>
+#include <vector>
+
 #include <mixpanel/mixpanel.hpp>
-#include <cmath>
-#include <chrono>
+
 #include "./persistence.hpp"
 #include "./worker.hpp"
 #include "platform_helpers.hpp"
@@ -471,4 +474,4 @@ namespace mixpanel
         return ret;
     }
 
-}
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/people.cpp
+++ b/native/source/mixpanel/detail/people.cpp
@@ -1,3 +1,5 @@
+#include <string>
+
 #include <mixpanel/mixpanel.hpp>
 #include "platform_helpers.hpp"
 
@@ -143,5 +145,4 @@ namespace mixpanel
         }
     }
 
-
-}
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/persistence.cpp
+++ b/native/source/mixpanel/detail/persistence.cpp
@@ -1,5 +1,7 @@
-#include <iostream>
 #include <algorithm>
+#include <iostream>
+#include <string>
+#include <utility>
 #include "./persistence.hpp"
 #include "./platform_helpers.hpp"
 
@@ -160,5 +162,5 @@ namespace mixpanel
         {
             Persistence::maximum_queue_size = maximum_size;
         }
-    }
-}
+    } // namespace detail
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/persistence.hpp
+++ b/native/source/mixpanel/detail/persistence.hpp
@@ -1,12 +1,14 @@
 #ifndef _PERSISTENCE_HPP_
 #define _PERSISTENCE_HPP_
 
-#include <fstream>
-#include <cassert>
-#include <mutex>
-#include <mixpanel/value.hpp>
 #include <atomic>
 #include <list>
+#include <map>
+#include <mutex>
+#include <string>
+#include <utility>
+
+#include <mixpanel/value.hpp>
 
 class Persistence_TestDropFront_Test;
 class Mixpanel_HugeRequest_Test;
@@ -70,7 +72,7 @@ namespace mixpanel
                 typedef std::map<std::string, std::list<Value>> Memory_queues;
                 static Memory_queues memory_queues;
         };
-    }
-}
+    } // namespace detail
+} // namespace mixpanel
 
 #endif /* _PERSISTENCE_HPP_ */

--- a/native/source/mixpanel/detail/platform_helpers.cpp
+++ b/native/source/mixpanel/detail/platform_helpers.cpp
@@ -1,9 +1,12 @@
 #include "platform_helpers.hpp"
-#include <fstream>
 #include <codecvt>
+#include <fstream>
+#include <iomanip>
 #include <locale>
 #include <sstream>
-#include <iomanip>
+#include <string>
+#include <utility>
+#include <vector>
 
 #if defined(__ANDROID__)
 #   include <unistd.h>
@@ -21,7 +24,6 @@
 #        include <Objbase.h>
 #        include <wrl.h>
 #        include <windows.storage.h>
-#        include <codecvt>
 #    endif
 #endif
 
@@ -383,5 +385,5 @@ namespace mixpanel
         }
 #endif
         #endif /* __ANDROID__ */
-    }
-}
+    } // namespace detail
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/platform_helpers.hpp
+++ b/native/source/mixpanel/detail/platform_helpers.hpp
@@ -33,7 +33,7 @@ namespace mixpanel
             static Value collect_automatic_properties();
             static Value collect_automatic_people_properties();
         };
-    }
-}
+    } // namespace detail
+} // namespace mixpanel
 
 #endif //MIXPANEL_PLATFORM_HELPERS_HPP

--- a/native/source/mixpanel/detail/workarounds.hpp
+++ b/native/source/mixpanel/detail/workarounds.hpp
@@ -2,6 +2,10 @@
 #define MIXPANEL_WORKAROUNDS_HPP
 
 #if defined(__ANDROID__)
+
+#include <sstream>
+#include <string>
+
 namespace std
 {
     template <typename T>
@@ -11,7 +15,8 @@ namespace std
         ss << t;
         return ss.str();
     }
-}
+} // namespace std
+
 #endif
 
 #endif //MIXPANEL_WORKAROUNDS_HPP

--- a/native/source/mixpanel/detail/worker.cpp
+++ b/native/source/mixpanel/detail/worker.cpp
@@ -1,10 +1,15 @@
 #include <algorithm>
-#include <math.h>
-#include "./worker.hpp"
+#include <cmath>
+#include <map>
+#include <string>
+#include <utility>
+
+#include <mixpanel/mixpanel.hpp>
 #include <mixpanel/value.hpp>
+
+#include "./worker.hpp"
 #include "./base64.hpp"
 #include "./persistence.hpp"
-#include <mixpanel/mixpanel.hpp>
 #include "./workarounds.hpp"
 
 namespace mixpanel
@@ -35,14 +40,14 @@ namespace mixpanel
         #endif
 
         #ifdef HAVE_MBEDTLS
-        const static std::string api_host = "https://api.mixpanel.com/";
+        static const std::string api_host = "https://api.mixpanel.com/";
         #else
-        const static std::string api_host = "";
+        static const std::string api_host = "";
         #endif
 
         static std::string encode(const Value& v);
 
-        const static bool verbose = true;
+        static const bool verbose = true;
 
         Worker::Worker(Mixpanel* mixpanel)
         : mixpanel(mixpanel)
@@ -173,7 +178,6 @@ namespace mixpanel
                 {
                     return {false, "failed to parse: " + response.content()};
                 }
-
             }
 
             return {false, client.errstr()};
@@ -311,5 +315,5 @@ namespace mixpanel
                 }
             }
         }
-    }
-}
+    } // namespace detail
+} // namespace mixpanel

--- a/native/source/mixpanel/detail/worker.hpp
+++ b/native/source/mixpanel/detail/worker.hpp
@@ -1,12 +1,13 @@
 #ifndef _MIXPANEL_WORKER_HPP_
 #define _MIXPANEL_WORKER_HPP_
 
-#include <memory>
-#include <string>
-#include <thread>
-#include <mutex>
 #include <atomic>
 #include <condition_variable>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <utility>
 #include <mixpanel/value.hpp>
 #include "../../../tests/gtest/include/gtest/gtest_prod.h"
 #include "../../dependencies/nano/include/nanowww/nanowww.h"
@@ -24,7 +25,7 @@ namespace mixpanel
         class Worker
         {
             public:
-                Worker(Mixpanel* mixpanel);
+                explicit Worker(Mixpanel* mixpanel);
                 ~Worker();
 
                 void enqueue(const std::string& name, const Value& o);
@@ -66,7 +67,7 @@ namespace mixpanel
                 std::mutex mutex;
                 std::condition_variable condition;
         };
-    }
-}
+    } // namespace detail
+} // namespace mixpanel
 
 #endif


### PR DESCRIPTION
Comments on namespaces. [readability/namespace]
Make `Worker`'s single-argument constructor explicit. [runtime/explicit]
Include-what-you-use for headers. [build/include_what_you_use]
Replace `const static x` with `static const x`. [build/storage_class]
Remove some blank lines. [whitespace/blank_line]

No functional change.