### PR TITLE
Batch mode unity operations can cause MixpanelPostprocessor to run at the wrong time.

### DIFF
--- a/deployments/UnityMixpanel/Assets/Mixpanel/Editor/Mixpanel/MixpanelPostprocessor.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/Editor/Mixpanel/MixpanelPostprocessor.cs
@@ -1,5 +1,4 @@
-﻿#if UNITY_IOS
-using UnityEngine;
+﻿using UnityEngine;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using MixpanelSDK.UnityEditor.iOS.Xcode;
@@ -13,6 +12,10 @@ public class MixpanelPostprocessScript : MonoBehaviour
     [PostProcessBuild]
     public static void OnPostprocessBuild(BuildTarget target, string buildPath)
     {
+        //Don't do any of this if we aren't building for iOS
+        if( BuildTarget.iOS != target )
+            return;
+
         UnityEngine.Debug.Log("******** START Mixpanel iOS Postprocess Script ********");
 
         // Find the xcodeproj based on the build path
@@ -53,4 +56,3 @@ public class MixpanelPostprocessScript : MonoBehaviour
         project.RemoveFile(bundleGuid);
     }
 }
-#endif


### PR DESCRIPTION
If you build unity using batch mode command line, using UNITY_IOS to block the entire file out can cause the modifications to try and run on android (if you are switching a project out of IOS) or not to run at all (if you are switching to IOS from android)

Doing a quick runtime check up front and having it attempt to run every time makes batch mode building reliable.