### PR TITLE
Update mixpanel.cpp

### DIFF
--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -247,8 +247,24 @@ namespace mixpanel
 
         if (unique_id != get_distinct_id())
         {
-            state["distinct_id"] = unique_id;
-            Persistence::write("state", state);
+            if (state["alias_id"].empty() || !state["alias_id"].isString() || state["alias_id"].asString().empty())
+            {
+                state["distinct_id"] = unique_id;
+                Persistence::write("state", state);
+            }
+            else
+            {
+                if(state["alias_id"] != unique_id)
+                {
+                    state["alias"] = "";
+                    state["distinct_id"] = unique_id;
+                    Persistence::write("state", state);
+                }
+                else
+                {
+                    log(LogEntry::LL_WARNING, "WARNING: unique_id matches current alias; keeping current distinct_id.");
+                }
+            }
         }
         else
         {
@@ -265,6 +281,8 @@ namespace mixpanel
             Value data;
             data["alias"] = alias;
             track("$create_alias", data);
+            state["alias_id"] = alias;
+            Persistence::write("state", state);
             identify(alias);
         }
         else

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -247,7 +247,7 @@ namespace mixpanel
 
         if (unique_id != get_distinct_id())
         {
-            if (state["alias_id"].empty() || !state["alias_id"].isString() || state["alias_id"].asString().empty())
+            if (!state["alias_id"].isString() || state["alias_id"].asString().empty())
             {
                 state["distinct_id"] = unique_id;
                 Persistence::write("state", state);
@@ -256,7 +256,7 @@ namespace mixpanel
             {
                 if(state["alias_id"] != unique_id)
                 {
-                    state["alias"] = "";
+                    state["alias_id"] = "";
                     state["distinct_id"] = unique_id;
                     Persistence::write("state", state);
                 }


### PR DESCRIPTION
Prevent race conditions when calling identify after alias:

- Adding the alias_id to persistent storage when alias is called
- When identify is called, prevent the unique ID from overriding the distinct_id if it is equal to the value for alias_id