### PR TITLE
make alias no longer identify. make alias persist, and protect users …

### DIFF
--- a/native/include/mixpanel/mixpanel.hpp
+++ b/native/include/mixpanel/mixpanel.hpp
@@ -259,6 +259,7 @@ namespace mixpanel
             static std::time_t utc_now_timestamp();
 
             std::string get_distinct_id() const;
+            std::string get_alias() const;
 
             std::string token;
             Value state;

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -184,9 +184,9 @@ namespace mixpanel
 
     std::string Mixpanel::get_alias() const
     {
-        if (state["alias"].isString())
+        if (!state["alias"].isNull() && state["alias"].isString())
         {
-            return state["distinct_id"].asString();
+            return state["alias"].asString();
         }
         else
         {

--- a/native/source/mixpanel/detail/mixpanel.cpp
+++ b/native/source/mixpanel/detail/mixpanel.cpp
@@ -184,7 +184,7 @@ namespace mixpanel
 
     std::string Mixpanel::get_alias() const
     {
-        if (!state["alias"].isNull() && state["alias"].isString())
+        if (state["alias"].isString() && !state["alias"].asString().empty())
         {
             return state["alias"].asString();
         }


### PR DESCRIPTION
…from identifying as their alias. more or less taken from the obj c library