### PR TITLE
Checking for null on getAdvertisingIdInfo

### DIFF
--- a/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
@@ -16,13 +16,11 @@ namespace mixpanel.platform
                 AndroidJavaClass client = new AndroidJavaClass("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 AndroidJavaObject adInfo = client.CallStatic<AndroidJavaObject>("getAdvertisingIdInfo",currentActivity);
                 if(adInfo != null){ 
-			return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
+                    return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
 		}
             }
             catch (AndroidJavaException e)
-            {
-                return null;
-            }
+            {}
 	    return null;
         }
 

--- a/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
@@ -15,7 +15,11 @@ namespace mixpanel.platform
                 AndroidJavaObject currentActivity = up.GetStatic<AndroidJavaObject>("currentActivity");
                 AndroidJavaClass client = new AndroidJavaClass("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 AndroidJavaObject adInfo = client.CallStatic<AndroidJavaObject>("getAdvertisingIdInfo",currentActivity);
-                return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
+                if(adInfo == null){ 
+					return null;
+				}else{
+					return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
+				}
             }
             catch (AndroidJavaException e)
             {

--- a/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
@@ -15,12 +15,14 @@ namespace mixpanel.platform
                 AndroidJavaObject currentActivity = up.GetStatic<AndroidJavaObject>("currentActivity");
                 AndroidJavaClass client = new AndroidJavaClass("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 AndroidJavaObject adInfo = client.CallStatic<AndroidJavaObject>("getAdvertisingIdInfo",currentActivity);
-                if(adInfo != null){ 
+                if(adInfo != null)
+		{ 
                     return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
 		}
             }
             catch (AndroidJavaException e)
-            {}
+            {
+	    }
 	    return null;
         }
 

--- a/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
+++ b/deployments/UnityMixpanel/Assets/Mixpanel/MixpanelUnityPlatform.cs
@@ -15,16 +15,15 @@ namespace mixpanel.platform
                 AndroidJavaObject currentActivity = up.GetStatic<AndroidJavaObject>("currentActivity");
                 AndroidJavaClass client = new AndroidJavaClass("com.google.android.gms.ads.identifier.AdvertisingIdClient");
                 AndroidJavaObject adInfo = client.CallStatic<AndroidJavaObject>("getAdvertisingIdInfo",currentActivity);
-                if(adInfo == null){ 
-					return null;
-				}else{
-					return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
-				}
+                if(adInfo != null){ 
+			return adInfo.Call<string>("getId"); // note: we're not using the id for advertising
+		}
             }
             catch (AndroidJavaException e)
             {
                 return null;
             }
+	    return null;
         }
 
         public static string get_android_id()


### PR DESCRIPTION
getAdvertisingIdInfo can return null in some instances where devices have a version of Google Play Services 9.8 or above. Adding an additional check since it is not caught by the AndroidJavaException
playgameservices/android-basic-samples#240