### PR TITLE
Add session metadata for deduplication purposes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ sysinfo.txt
 # Builds
 *.apk
 # Custom
+.vscode/

--- a/Mixpanel/Mixpanel.cs
+++ b/Mixpanel/Mixpanel.cs
@@ -13,7 +13,6 @@ namespace mixpanel
         
         private static Value _autoTrackProperties;
         private static Value _autoEngageProperties;
-
         private static Int32 _eventCounter = 0, _peopleCounter = 0, _sessionStartEpoch;
         private static String _sessionID;
 

--- a/Mixpanel/MixpanelManager.cs
+++ b/Mixpanel/MixpanelManager.cs
@@ -38,6 +38,13 @@ namespace mixpanel
         
         #endregion
 
+        void OnApplicationPause(bool pauseStatus)
+        {
+            if (!pauseStatus) {
+                Mixpanel.InitSession();
+            }
+        }
+
         private IEnumerator Start()
         {
             DontDestroyOnLoad(this);


### PR DESCRIPTION
Add `$mp_metadata` key as part of every track or people update. Used in the backend for deduplication purposes