### PR TITLE
Migrate state and super properties from old SDK to new SDK

### DIFF
--- a/Mixpanel/MixpanelPersistance.cs
+++ b/Mixpanel/MixpanelPersistance.cs
@@ -8,6 +8,18 @@ namespace mixpanel
 {
     public static partial class Mixpanel
     {
+        #region HasMigratedFrom1To2
+
+        private const string HasMigratedFrom1To2Name = "Mixpanel.HasMigratedFrom1To2";
+
+        public static bool HasMigratedFrom1To2
+        {
+            get => Convert.ToBoolean(PlayerPrefs.GetInt(HasMigratedFrom1To2Name, 0));
+            set => PlayerPrefs.SetInt(HasMigratedFrom1To2Name, Convert.ToInt32(value));
+        }
+
+        #endregion
+
         #region HasIntegratedLibrary
 
         private const string HasIntegratedLibraryName = "Mixpanel.HasIntegratedLibrary";
@@ -69,7 +81,7 @@ namespace mixpanel
                 else _isTracking = PlayerPrefs.GetInt(IsTrackingName) == 1;
                 return _isTracking;
             }
-            private set
+            set
             {
                 _isTracking = value;
                 PlayerPrefs.SetInt(IsTrackingName, _isTracking ? 1 : 0);

--- a/Mixpanel/MixpanelValue.cs
+++ b/Mixpanel/MixpanelValue.cs
@@ -817,7 +817,7 @@ namespace mixpanel
             }
             return sb.ToString();
         }
-
+        
         #endregion
 
         #region UnitySerialization
@@ -891,5 +891,289 @@ namespace mixpanel
             }
         }
         #endregion
+
+        // Only used to migrate from 1.X to 2.X - Will be removed soon
+        #region Deserialize
+
+        public static Value Deserialize(string json)
+        {
+            return ParseValue(new StringReader(json));
+        }
+
+        private static Value ParseValue(StringReader reader)
+        {
+            return ParseByToken(reader, NextToken(reader));
+        }
+
+        private static Value ParseByToken(StringReader reader, Token token)
+        {
+            switch (token) {
+                case Token.STRING:
+                    return ParseString(reader);
+                case Token.NUMBER:
+                    return ParseNumber(reader);
+                case Token.CURLY_OPEN:
+                    // ditch opening brace
+                    reader.Read();
+                    return ParseObject(reader);
+                case Token.SQUARED_OPEN:
+                    // ditch opening bracket
+                    reader.Read();
+                    return ParseArray(reader);
+                case Token.TRUE:
+                    return true;
+                case Token.FALSE:
+                    return false;
+                case Token.NULL:
+                    return Value.Null;
+                default:
+                    return Value.Null;
+            }
+        }
+
+        private static string ParseString(StringReader reader)
+        {
+            StringBuilder s = new StringBuilder();
+            
+            // ditch opening quote
+            reader.Read();
+            
+            bool parsing = true;
+            while (parsing) {
+
+                if (reader.Peek() == -1) {
+                    parsing = false;
+                    break;
+                }
+
+                char c = NextChar(reader);
+                switch (c) {
+                case '"':
+                    parsing = false;
+                    break;
+                case '\\':
+                    if (reader.Peek() == -1) {
+                        parsing = false;
+                        break;
+                    }
+
+                    c = NextChar(reader);
+                    switch (c) {
+                        case '"':
+                        case '\\':
+                        case '/':
+                            s.Append(c);
+                            break;
+                        case 'b':
+                            s.Append('\b');
+                            break;
+                        case 'f':
+                            s.Append('\f');
+                            break;
+                        case 'n':
+                            s.Append('\n');
+                            break;
+                        case 'r':
+                            s.Append('\r');
+                            break;
+                        case 't':
+                            s.Append('\t');
+                            break;
+                        case 'u':
+                            StringBuilder hex = new StringBuilder();
+
+                            for (int i=0; i< 4; i++) {
+                                hex.Append(NextChar(reader));
+                            }
+
+                            s.Append((char) Convert.ToInt32(hex.ToString(), 16));
+                            break;
+                    }
+                    break;
+                default:
+                    s.Append(c);
+                    break;
+                }
+            }
+
+            return s.ToString();
+        }
+        
+        private static double ParseNumber(StringReader reader)
+        {
+            string number = NextWord(reader);
+            double.TryParse(number, out double parsedDouble);
+            return parsedDouble;
+        }
+        
+        private static Value ParseArray(StringReader reader)
+        {
+            List<Value> array = new List<Value>();
+
+            bool parsing = true;
+            while (parsing) {
+                Token nextToken = NextToken(reader);
+
+                switch (nextToken) {
+                    case Token.NONE:
+                        return null;
+                    case Token.COMMA:
+                        continue;
+                    case Token.SQUARED_CLOSE:
+                        parsing = false;
+                        break;
+                    default:
+                        array.Add(ParseByToken(reader, nextToken));
+                        break;
+                }
+            }
+
+            return new Value(array);
+        }
+        
+        private static Value ParseObject(StringReader reader)
+        {
+            Dictionary<string, Value> data = new Dictionary<string, Value>();
+
+            while (true) {
+                switch (NextToken(reader)) {
+                    case Token.NONE:
+                        return null;
+                    case Token.COMMA:
+                        continue;
+                    case Token.CURLY_CLOSE when data.ContainsKey("JsonType") && data.ContainsKey("DataType"):
+                        return FromSerialization(data["JsonType"], data["DataType"], data["Value"]);
+                    case Token.CURLY_CLOSE:
+                        return new Value(data);
+                    default:
+                        // key
+                        string key = ParseString(reader);
+                        if (key == null) {
+                            return null;
+                        }
+                        // :
+                        if (NextToken(reader) != Token.COLON) {
+                            return null;
+                        }
+                        // ditch the colon
+                        reader.Read();
+
+                        // value
+                        data[key] = ParseValue(reader);
+                        break;
+                }
+            }
+        }
+
+        private const string WhiteSpace = " \t\n\r";
+        private const string WordBreak = " \t\n\r{}[],:\"";
+
+        private enum Token
+        {
+            NONE,
+            CURLY_OPEN,
+            CURLY_CLOSE,
+            SQUARED_OPEN,
+            SQUARED_CLOSE,
+            COLON,
+            COMMA,
+            STRING,
+            NUMBER,
+            TRUE,
+            FALSE,
+            NULL
+        };
+        
+        private static char PeekChar(StringReader reader) => Convert.ToChar(reader.Peek());
+
+        private static char NextChar(StringReader reader) => Convert.ToChar(reader.Read());
+
+        private static string NextWord(StringReader reader)
+        {
+            StringBuilder word = new StringBuilder();
+            while (WordBreak.IndexOf(PeekChar(reader)) == -1) {
+                word.Append(NextChar(reader));
+
+                if (reader.Peek() == -1) {
+                    break;
+                }
+            }
+            return word.ToString();
+        }
+
+        private static void EatWhitespace(StringReader reader)
+        {
+            while (WhiteSpace.IndexOf(PeekChar(reader)) != -1) {
+                reader.Read();
+
+                if (reader.Peek() == -1) {
+                    break;
+                }
+            }
+        }
+
+        private static Token NextToken(StringReader reader)
+        {
+            EatWhitespace(reader);
+
+            if (reader.Peek() == -1) {
+                return Token.NONE;
+            }
+
+            char c = PeekChar(reader);
+            switch (c) {
+                case '{':
+                    return Token.CURLY_OPEN;
+                case '}':
+                    reader.Read();
+                    return Token.CURLY_CLOSE;
+                case '[':
+                    return Token.SQUARED_OPEN;
+                case ']':
+                    reader.Read();
+                    return Token.SQUARED_CLOSE;
+                case ',':
+                    reader.Read();
+                    return Token.COMMA;
+                case '"':
+                    return Token.STRING;
+                case ':':
+                    return Token.COLON;
+                case '0':
+                case '1':
+                case '2':
+                case '3':
+                case '4':
+                case '5':
+                case '6':
+                case '7':
+                case '8':
+                case '9':
+                case '-':
+                    return Token.NUMBER;
+            }
+
+            string word = NextWord(reader);
+
+            switch (word) {
+                case "false":
+                    return Token.FALSE;
+                case "true":
+                    return Token.TRUE;
+                case "null":
+                    return Token.NULL;
+            }
+
+            return Token.NONE;
+        }
+
+        private static Value FromSerialization(Value valueType, Value dataType, Value value)
+        {
+            value._valueType = (ValueTypes) Enum.Parse(typeof(ValueTypes), valueType);
+            value._dataType = (DataTypes) Enum.Parse(typeof(DataTypes), dataType);
+            return value;
+        }
+        #endregion
+
     }
 }


### PR DESCRIPTION
Persist state (`distinct_id`, `opted_out` and `tracked_integration`) as well as all user-defined super properties from our old SDK version to the new one