### PR TITLE
Remove ClearCharges from OptOutTracking

### DIFF
--- a/Mixpanel/MixpanelAPI.cs
+++ b/Mixpanel/MixpanelAPI.cs
@@ -82,8 +82,6 @@ namespace mixpanel
         /// </summary>
         public static void OptOutTracking()
         {
-            People.ClearCharges();
-            Flush();
             People.DeleteUser();
             Flush();
             Reset();


### PR DESCRIPTION
Removing  the call to People.ClearCharges() from the OptOutTracking function. Within this function, there is a Profile deletion which would also clear transactions and it also generates a race condition that could create empty profiles.