### PR TITLE
Config.ShowDebug cannot be overridden.

### DIFF
--- a/Mixpanel/MixpanelSettings.cs
+++ b/Mixpanel/MixpanelSettings.cs
@@ -54,6 +54,13 @@ namespace mixpanel
         public static MixpanelSettings Instance {
             get {
                 LoadSettings();
+                
+                // Be sure to respect the programmatic setting of values over the Unity UI's version of the settings (since they are set later)
+                if (Config.ShowDebug != _instance.ShowDebug) {
+                    Mixpanel.Log($"Mixpanel: Overriding ShowDebug from editor setting [{Config.ShowDebug}] with MixpanelSettings ShowDebug setting [{_instance.ShowDebug}]");
+                    Config.ShowDebug = _instance.ShowDebug;
+                }
+                
                 return _instance;
             }
         }


### PR DESCRIPTION
When a user sets the MixpanelSettings ShowDebug, it has no effect.  The Unity object's setting for ShowDebug (Config.ShowDebug) overrides this and makes it impossible to turn off mixpanel logging.  If the log settings are different, use the programmatically set one (because it is done at runtime, and later, and potentially more purposeful) and log a message indicating that there has been a conflict.