### PR TITLE
Fix fatal error in Mixpanel.Reset() at application boot

### DIFF
--- a/Mixpanel/Worker.cs
+++ b/Mixpanel/Worker.cs
@@ -264,7 +264,12 @@ namespace mixpanel
                     {
                         byte[] data = session.Dequeue();
                         if (data == null) break;
-                        batch.Add(JsonUtility.FromJson<Value>(Encoding.UTF8.GetString(data)));
+                        try {
+                            batch.Add(JsonUtility.FromJson<Value>(Encoding.UTF8.GetString(data)));
+                        }
+                        catch (Exception e) {
+                            Mixpanel.LogError($"There was an error processing event [{count}] from the internal object pool: " + e);
+                        }
                         ++count;
                     }
                     if (count == 0) yield break;


### PR DESCRIPTION
We encountered a rare crash on boot from mixpanel when it was trying to load data from locally stored files which contained malformed JSON.

ArgumentException: JSON parse error: The document is empty.
  at UnityEngine.JsonUtility.FromJson[T] (System.String json) [0x00000] in <00000000000000000000000000000000>:0
  at mixpanel.MixpanelManager+<DoRequest>d__15.MoveNext () [0x00000] in <00000000000000000000000000000000>:0
  at UnityEngine.SetupCoroutine.InvokeMoveNext (System.Collections.IEnumerator enumerator, System.IntPtr returnValueAddress) [0x00000] in <00000000000000000000000000000000>:0
  at mixpanel.MixpanelManager.DoFlush (System.String url, mixpanel.queue.PersistentQueue queue) [0x00000] in <00000000000000000000000000000000>:0
  at mixpanel.MixpanelManager.Flush () [0x00000] in <00000000000000000000000000000000>:0
  at mixpanel.Mixpanel.Reset () [0x00000] in <00000000000000000000000000000000>:0


This was rare, but happens right on boot-up for some devices, and the user can't play the mobile app again without deleting all data and re-installing the app (in order to delete malformed mixpanel JSON locally stored on the device).

Mixpanel should NEVER crash an application, and anything dangerous should be surrounded with try/catch and protected appropriately.
