### PR TITLE
Additional protection around UnityWebRequest.Post call.

### DIFF
--- a/Mixpanel/Worker.cs
+++ b/Mixpanel/Worker.cs
@@ -297,11 +297,19 @@ namespace mixpanel
                     {
                         WWWForm form = new WWWForm();
                         form.AddField("data", payload);
-                        UnityWebRequest request = UnityWebRequest.Post(url, form);
-                        yield return request.SendWebRequest();
-                        while (!request.isDone) yield return new WaitForEndOfFrame();
-                        responseCode = (int) request.responseCode;
-                        response = request.downloadHandler.text;
+                        UnityWebRequest request = null;
+                        try {
+                            request = UnityWebRequest.Post(url, form);
+                        }
+                        catch (Exception e) {
+                            Mixpanel.LogError($"There was an error sending information to mixpanel servers: " + e);
+                        }
+                        if (request != null) {
+                            yield return request.SendWebRequest();
+                            while (!request.isDone) yield return new WaitForEndOfFrame();
+                            responseCode = (int) request.responseCode;
+                            response = request.downloadHandler.text;
+                        }
                     }
 
                     Mixpanel.Log($"Response - '{url}' was '{response}'");

--- a/Mixpanel/Worker.cs
+++ b/Mixpanel/Worker.cs
@@ -264,7 +264,12 @@ namespace mixpanel
                     {
                         byte[] data = session.Dequeue();
                         if (data == null) break;
-                        batch.Add(JsonUtility.FromJson<Value>(Encoding.UTF8.GetString(data)));
+                        try {
+                            batch.Add(JsonUtility.FromJson<Value>(Encoding.UTF8.GetString(data)));
+                        }
+                        catch (Exception e) {
+                            Mixpanel.LogError($"There was an error processing event [{count}] from the internal object pool: " + e);
+                        }
                         ++count;
                     }
                     if (count == 0) yield break;


### PR DESCRIPTION
Additional protection added around UnityWebRequest post calls.  We did not see a crash in this area, but if mixpanel does crash here, it should fail gracefully, not exception and kill the game it's running inside.