### PR TITLE
Customize player preferences

### DIFF
--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -351,17 +351,18 @@ namespace mixpanel
         {
             private static Int32 _eventCounter = 0, _peopleCounter = 0, _sessionStartEpoch;
             private static String _sessionID;
+            private static System.Random _random = new System.Random(Guid.NewGuid().GetHashCode());
 
             internal static void InitSession() {
                 _eventCounter = 0;
                 _peopleCounter = 0;
-                _sessionID = Convert.ToString(UnityEngine.Random.Range(0, Int32.MaxValue), 16);
+                _sessionID = Convert.ToString(_random.Next(0, Int32.MaxValue), 16);
                 _sessionStartEpoch = (Int32)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
             }
             internal static Value GetEventMetadata() {
                 Value eventMetadata = new Value
                 {
-                    {"$mp_event_id", Convert.ToString(UnityEngine.Random.Range(0, Int32.MaxValue), 16)},
+                    {"$mp_event_id", Convert.ToString(_random.Next(0, Int32.MaxValue), 16)},
                     {"$mp_session_id", _sessionID},
                     {"$mp_session_seq_id", _eventCounter},
                     {"$mp_session_start_sec", _sessionStartEpoch}
@@ -373,7 +374,7 @@ namespace mixpanel
             internal static Value GetPeopleMetadata() {
                 Value peopleMetadata = new Value
                 {
-                    {"$mp_event_id", Convert.ToString(UnityEngine.Random.Range(0, Int32.MaxValue), 16)},
+                    {"$mp_event_id", Convert.ToString(_random.Next(0, Int32.MaxValue), 16)},
                     {"$mp_session_id", _sessionID},
                     {"$mp_session_seq_id", _peopleCounter},
                     {"$mp_session_start_sec", _sessionStartEpoch}

--- a/Mixpanel/IPreferences.cs
+++ b/Mixpanel/IPreferences.cs
@@ -1,0 +1,15 @@
+
+namespace mixpanel
+{
+    public interface IPreferences
+    {
+        void DeleteKey(string key);
+        int GetInt(string key);
+        int GetInt(string key, int defaultValue);
+        string GetString(string key);
+        string GetString(string key, string defaultValue);
+        bool HasKey(string key);
+        void SetInt(string key, int value);
+        void SetString(string key, string value);
+    }
+}

--- a/Mixpanel/IPreferences.cs.meta
+++ b/Mixpanel/IPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1230616897949d949b682225a1e4d192
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Mixpanel/PlayerPreferences.cs
+++ b/Mixpanel/PlayerPreferences.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+
+namespace mixpanel
+{
+    public class PlayerPreferences : IPreferences
+    {
+        public void DeleteKey(string key)
+        {
+            PlayerPrefs.DeleteKey(key);
+        }
+        
+        public float GetFloat(string key)
+        {
+            return PlayerPrefs.GetFloat(key);
+        }
+
+        public int GetInt(string key)
+        {
+            return PlayerPrefs.GetInt(key);
+        }
+
+        public int GetInt(string key, int defaultValue)
+        {
+            return PlayerPrefs.GetInt(key, defaultValue);
+        }
+
+        public string GetString(string key)
+        {
+            return PlayerPrefs.GetString(key);
+        }
+
+        public string GetString(string key, string defaultValue)
+        {
+            return PlayerPrefs.GetString(key, defaultValue);
+        }
+
+        public bool HasKey(string key)
+        {
+            return PlayerPrefs.HasKey(key);
+        }
+
+        public void SetInt(string key, int value)
+        {
+            PlayerPrefs.SetInt(key, value);
+        }
+
+        public void SetString(string key, string value)
+        {
+            PlayerPrefs.SetString(key, value);
+        }
+    }
+}

--- a/Mixpanel/PlayerPreferences.cs.meta
+++ b/Mixpanel/PlayerPreferences.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: edcd1ac2d0e7eba498446cd39dc68546
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR's purpose is to make it possible to run `Mixpanel.Track` function from other threads. the changes are:

* Allowing the user to provide a different settings source than Unity's `PlayerPrefs`
* Using .NET random generator instead of Unity, since Unity's random generator can be used only from main thread
