### PR TITLE
Optimize PlayerPrefs event ID scanning when sending event batches

### DIFF
--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -237,6 +237,15 @@ namespace mixpanel
                 }
                 dataIndex++;
             }
+
+            if (dataIndex == maxIndex) {
+                // We want to avoid maxIndex from getting too high while having large "empty gaps" stored in PlayerPrefs, otherwise
+                // there can be a large number of string concatenation and PlayerPrefs API calls (in extreme cases, 100K+).
+                // At this point, we should have iterated through all possible event IDs and can assume that there are no other events
+                // stored in preferences (since we deleted them all).
+                string idKey = (flushType == FlushType.EVENTS) ? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
+                PreferencesSource.SetInt(idKey, 0);
+            }
         }
 
         internal static void DeleteBatchTrackingData(Value batch) {

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -168,6 +168,11 @@ namespace mixpanel
         private const string EventAutoIncrementingIdName = "EventAutoIncrementingID";
         private const string PeopleAutoIncrementingIdName = "PeopleAutoIncrementingID";
 
+        // For performance, we can store the lowest unsent event ID to prevent searching from 0.
+        // This search process can be slow if the auto-increment ID gets large enough.
+        private const string EventStartIndexName = "EventStartIndex";
+        private const string PeopleStartIndexName = "PeopleStartIndex";
+
         internal enum FlushType
         {
             EVENTS,
@@ -194,6 +199,16 @@ namespace mixpanel
             return PreferencesSource.GetInt(PeopleAutoIncrementingIdName, 0);
         }
 
+        internal static int EventStartIndex()
+        {
+            return PreferencesSource.GetInt(EventStartIndexName, 0);
+        }
+
+        internal static int PeopleStartIndex()
+        {
+            return PreferencesSource.GetInt(PeopleStartIndexName, 0);
+        }
+
         private static void IncreaseTrackingDataID(FlushType flushType)
         {
             int id = (flushType == FlushType.EVENTS)? EventAutoIncrementingID() : PeopleAutoIncrementingID();
@@ -205,7 +220,10 @@ namespace mixpanel
         internal static Value DequeueBatchTrackingData(FlushType flushType, int batchSize)
         {
             Value batch = Value.Array;
-            int dataIndex = 0;
+            string startIndexKey = (flushType == FlushType.EVENTS) ? EventStartIndexName : PeopleStartIndexName;
+            int oldStartIndex = (flushType == FlushType.EVENTS) ? EventStartIndex() : PeopleStartIndex();
+            int newStartIndex = oldStartIndex;
+            int dataIndex = oldStartIndex;
             int maxIndex = (flushType == FlushType.EVENTS) ? EventAutoIncrementingID() - 1 : PeopleAutoIncrementingID() - 1;
             while (batch.Count < batchSize && dataIndex <= maxIndex) {
                 String trackingKey = (flushType == FlushType.EVENTS) ? "Event" + dataIndex.ToString() : "People" + dataIndex.ToString();
@@ -216,9 +234,22 @@ namespace mixpanel
                     catch (Exception e) {
                         Mixpanel.LogError($"There was an error processing '{trackingKey}' from the internal object pool: " + e);
                         PreferencesSource.DeleteKey(trackingKey);
+
+                        if (batch.Count == 0) {
+                            // Only update if we didn't find a key prior to deleting this key, since the prior key would be a lower valid index.
+                            newStartIndex = Math.Min(dataIndex + 1, maxIndex);
+                        }
                     }
                 }
+                else if (batch.Count == 0) {
+                    // Keep updating the start index as long as we haven't found anything for our batch yet -- we're looking for the minimum index.
+                    newStartIndex = Math.Min(dataIndex + 1, maxIndex);
+                }
                 dataIndex++;
+            }
+
+            if (newStartIndex != oldStartIndex) {
+                PreferencesSource.SetInt(startIndexKey, newStartIndex);
             }
             
             return batch;
@@ -227,7 +258,10 @@ namespace mixpanel
         internal static void DeleteBatchTrackingData(FlushType flushType, int batchSize)
         {
             int deletedCount = 0;
-            int dataIndex = 0;
+            string startIndexKey = (flushType == FlushType.EVENTS) ? EventStartIndexName : PeopleStartIndexName;
+            int oldStartIndex = (flushType == FlushType.EVENTS) ? EventStartIndex() : PeopleStartIndex();
+            int newStartIndex = oldStartIndex;
+            int dataIndex = oldStartIndex;
             int maxIndex = (flushType == FlushType.EVENTS) ? EventAutoIncrementingID() - 1 : PeopleAutoIncrementingID() - 1;
             while (deletedCount < batchSize && dataIndex <= maxIndex) {
                 String trackingKey = (flushType == FlushType.EVENTS) ? "Event" + dataIndex.ToString() : "People" + dataIndex.ToString();    
@@ -235,6 +269,7 @@ namespace mixpanel
                     PreferencesSource.DeleteKey(trackingKey);
                     deletedCount++;
                 }
+                newStartIndex = Math.Min(dataIndex + 1, maxIndex);
                 dataIndex++;
             }
 
@@ -245,6 +280,11 @@ namespace mixpanel
                 // stored in preferences (since we deleted them all).
                 string idKey = (flushType == FlushType.EVENTS) ? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
                 PreferencesSource.SetInt(idKey, 0);
+                PreferencesSource.SetInt(startIndexKey, 0);
+            }
+            else if (newStartIndex != oldStartIndex) {
+                // There are unsent batches, store the index of where to resume searching for next time.
+                PreferencesSource.SetInt(startIndexKey, newStartIndex);
             }
         }
 

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -165,6 +165,8 @@ namespace mixpanel
 
         #region Track
 
+        private const string EventAutoIncrementingIdName = "EventAutoIncrementingID";
+        private const string PeopleAutoIncrementingIdName = "PeopleAutoIncrementingID";
 
         internal enum FlushType
         {
@@ -184,19 +186,19 @@ namespace mixpanel
 
         internal static int EventAutoIncrementingID()
         {
-            return PreferencesSource.HasKey("EventAutoIncrementingID") ? PreferencesSource.GetInt("EventAutoIncrementingID") : 0;
+            return PreferencesSource.GetInt(EventAutoIncrementingIdName, 0);
         }
 
         internal static int PeopleAutoIncrementingID()
         {
-            return PreferencesSource.HasKey("PeopleAutoIncrementingID") ? PreferencesSource.GetInt("PeopleAutoIncrementingID") : 0;
+            return PreferencesSource.GetInt(PeopleAutoIncrementingIdName, 0);
         }
 
         private static void IncreaseTrackingDataID(FlushType flushType)
         {
             int id = (flushType == FlushType.EVENTS)? EventAutoIncrementingID() : PeopleAutoIncrementingID();
             id += 1;
-            String trackingIdKey = (flushType == FlushType.EVENTS)? "EventAutoIncrementingID" : "PeopleAutoIncrementingID";
+            String trackingIdKey = (flushType == FlushType.EVENTS)? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
             PreferencesSource.SetInt(trackingIdKey, id);
         }
 


### PR DESCRIPTION
This PR aims to fix performance issues when sending batches of events with high auto-increment IDs.

The performance issue stems from many string concatenations (`"Event" + dataIndex.ToString()`) and scanning `PlayerPrefs` for every ID between 0 and the next ID. This leads to a massive amount of GC allocations. The attached image is a snapshot of the Unity profiler which shows the issue in an extreme case: many events were sent throughout many app sessions.

![image](https://user-images.githubusercontent.com/32236920/193306107-d6940d5e-5896-4b3d-9029-018e941d65f3.png)

The solution to this is to reset the auto-increment ID to 0 after sending all batches successfully (I determine this by checking `dataIndex == maxIndex` when deleting data). I'm assuming that this ID is only used for local storage purposes to keep track of unsuccessful batches and nothing else.

The alternative fix is to store the starting index so the ID scan doesn't have to start from index 0 every time it sends out a batch of events. The starting index can be determined as the lowest event index that _wasn't_ sent yet.

Either method should mitigate/solve the issue, but we would want to at least keep the resetting the ID to 0 fix since it has less complexity.