### PR TITLE
Allow changing settings at runtime

### DIFF
--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -46,6 +46,8 @@ namespace mixpanel
         }
 
         internal static void Initialize() {
+            // Copy over any runtime changes that happened before initialization from settings instance to the config.
+            MixpanelSettings.Instance.ApplyToConfig();
             GetInstance();
         }
 

--- a/Mixpanel/MixpanelSettings.cs
+++ b/Mixpanel/MixpanelSettings.cs
@@ -37,6 +37,16 @@ namespace mixpanel
             }
         }
 
+        public void ApplyToConfig()
+        {
+            string host = APIHostAddress.EndsWith("/") ? APIHostAddress : $"{APIHostAddress}/";
+            Config.TrackUrl = string.Format(TrackUrlTemplate, host);
+            Config.EngageUrl = string.Format(EngageUrlTemplate, host);
+            Config.ShowDebug = ShowDebug;
+            Config.ManualInitialization = ManualInitialization;
+            Config.FlushInterval = FlushInterval;
+        }
+
         #region static
         private static MixpanelSettings _instance;
 
@@ -45,15 +55,10 @@ namespace mixpanel
             if (!_instance)
             {
                 _instance = FindOrCreateInstance();
-                string host = _instance.APIHostAddress.EndsWith("/") ? _instance.APIHostAddress : $"{_instance.APIHostAddress}/";
-                Config.TrackUrl = string.Format(TrackUrlTemplate, host);
-                Config.EngageUrl = string.Format(EngageUrlTemplate, host);
-                Config.ShowDebug = _instance.ShowDebug;
-                Config.ManualInitialization = _instance.ManualInitialization;
-                Config.FlushInterval = _instance.FlushInterval;
+                _instance.ApplyToConfig();
             }
         }
-    
+
         public static MixpanelSettings Instance {
             get {
                 LoadSettings();


### PR DESCRIPTION
Adds a way to change the config at runtime, which is useful when changing the API host based on app environment for example. Any changes made to `MixpanelSettings.Instance` will be copied over after manually initializing the library.

Closes #101 (this PR is more general-purpose), #148


## Usage
Before initialization:
``` csharp
MixpanelSettings.Instance.APIHostAddress = "https://myproxy.com";
...
// automatically copies to internal config
Mixpanel.Init();
```
``` csharp
MixpanelSettings.Instance.APIHostAddress = "https://myproxy.com";
...
// valid but redundant since Init() will call this automatically
MixpanelSettings.Instance.ApplyToConfig();
Mixpanel.Init();
```

After initialization:
``` csharp
Mixpanel.Init();
MixpanelSettings.Instance.APIHostAddress = "https://myproxy.com";
...
// must call this for changes to take effect since changes were made after Init().
MixpanelSettings.Instance.ApplyToConfig();
```