### PR TITLE
Add onFlushComplete callback

### DIFF
--- a/Mixpanel/MixpanelAPI.cs
+++ b/Mixpanel/MixpanelAPI.cs
@@ -290,10 +290,11 @@ namespace mixpanel
         /// <summary>
         /// Flushes the queued data to Mixpanel
         /// </summary>
-        public static void Flush()
+        /// <param name="onFlushComplete">callback to be called when the flush is complete. Returns true if overall success</param>
+        public static void Flush(Action<bool> onFlushComplete = null)
         {
             if (!IsInitialized()) return;
-            Controller.GetInstance().DoFlush();
+            Controller.GetInstance().DoFlush(onFlushComplete);
         }
 
         /// <summary>


### PR DESCRIPTION
Consider the following scenario:
* The user shuts down the application
* We generate events that are related to this, and want to flush them before shutdown completes
* In order to do this, we need to know that the Flush command has finished so that shutdown can proceed

This PR adds an optional callback that will be invoked once Flush has finished. In addition, it can signal the caller if the flush was successful or not.

@zihejia 