### PR TITLE
Update default ValueType for Value class

### DIFF
--- a/Mixpanel/Value.cs
+++ b/Mixpanel/Value.cs
@@ -42,7 +42,7 @@ namespace mixpanel
             RECT
         }
 
-        [SerializeField] private ValueTypes _valueType = ValueTypes.OBJECT;
+        [SerializeField] private ValueTypes _valueType = ValueTypes.UNDEFINED;
         [SerializeField] private DataTypes _dataType = DataTypes.UNDEFINED;
         [SerializeField] private string _string;
         [SerializeField] private bool _bool;


### PR DESCRIPTION
It is difficult at the moment to create ArrayVallues because when Value is created with empty constructor it is marked as an Object value type;

it should be instead Undefined until it is assigned a value or added a value through one of add methofs or indexing operator,

possible drowback is that now when creating dictionary indexed by int keys it will require explicit usage of add method instead of [] at least for first add as indexer assignment would create an array instead of object.