### PR TITLE
Add missing meta files for documentation and scripts

### DIFF
--- a/AGENTS.md.meta
+++ b/AGENTS.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b47aa238069ce48a4866b39859b291e1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CLAUDE.md.meta
+++ b/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 93d53954c4ebf44ada62e4a8b257b49d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts.meta
+++ b/scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0547599ac9ab34074bc5004a39d58da4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/scripts/release.py.meta
+++ b/scripts/release.py.meta
@@ -1,0 +1,10 @@
+fileFormatVersion: 2
+guid: f790db4375dae46479830415f1bb11b3
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 11500000, guid: d68ef794590944f1ea7ee102c91887c7, type: 3}


### PR DESCRIPTION
## Summary
- Adds missing `.meta` files for documentation and build scripts that exist in the repository
- Resolves Unity warnings about missing meta files when users clone the repository

## Problem
Unity generates `.meta` files for all files in a Unity project, including documentation and build scripts. These files weren't committed to the repository, causing:
- Unity warnings about missing meta files
- Untracked `.meta` files appearing in users' working directories

## Solution
Following Unity package conventions, this PR commits the `.meta` files for:
- `AGENTS.md.meta`
- `CLAUDE.md.meta`
- `scripts.meta`
- `scripts/release.py.meta`

This is the standard approach for Unity packages - all files have accompanying `.meta` files to maintain consistent import settings across all development environments.

## Test Plan
- [x] Clone the repository in a fresh Unity project
- [x] Verify no warnings about missing meta files
- [x] Confirm no untracked `.meta` files are generated