### PR TITLE
[DEV-72] chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       # Note: .NET SDK provides basic C# syntax support for Copilot.
       # This Unity SDK uses Unity-specific APIs (UnityEngine, UnityEditor)
@@ -24,7 +24,7 @@ jobs:
       # for Unity-specific code will be limited. However, this still helps with
       # general C# syntax, patterns, and non-Unity code analysis.
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9  # v4
         with:
           dotnet-version: '6.0.x'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check-out"
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e  # v1
       - name: "Update Release CHANGELOG"
         id: update-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
+        uses: heinrichreimer/github-changelog-generator-action@854576bb5274851427527d8199fba0061552dff5  # v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           onlyLastTag: true
@@ -38,14 +38,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "Update CHANGELOG"
       - name: Push CHANGELOG changes
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@40bf560936a8022e68a3c00e7d2abefaf01305a6  # v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: master
           force: true
       - name: "Prepare for the Github Release"
         id: generate-release-changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
+        uses: heinrichreimer/github-changelog-generator-action@854576bb5274851427527d8199fba0061552dff5  # v2.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           output: "output.md"
@@ -63,7 +63,7 @@ jobs:
           author: false
           verbose: true
       - name: "🚀 Create GitHub Release"
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary
Pin all GitHub Actions workflow steps to immutable full commit SHAs instead of mutable tags or branches.

## Why
Mutable tags can be moved after the fact, making it possible for a supply-chain attack to inject malicious code into CI. Pinning to a commit SHA ensures the exact version of an action is used, and the original tag is preserved as an inline comment for readability.

## Verification
Review the diff — all `uses:` lines with third-party actions should now reference a 40-character commit SHA with the original tag as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: https://linear.app/mixpanel/issue/DEV-72/pin-all-github-actions-to-commit-shas