### PR TITLE
Performance: reduce IL2CPP bloat, boot-time cost, and runtime memory

### DIFF
--- a/Mixpanel/Config.cs
+++ b/Mixpanel/Config.cs
@@ -10,8 +10,5 @@ namespace mixpanel
         internal static float FlushInterval = 60f;
 
         internal static int BatchSize = 50;
-
-        internal const int PoolFillFrames = 50;
-        internal const int PoolFillEachFrame = 20;
     }
 }

--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -310,7 +310,7 @@ namespace mixpanel
                     else
                     {
                         _retryCount = 0;
-                        MixpanelStorage.DeleteBatchTrackingData(batch);
+                        MixpanelStorage.DeleteBatchTrackingData(flushType, batch);
                         batch = MixpanelStorage.DequeueBatchTrackingDataRaw(flushType, Config.BatchSize);
                         Mixpanel.Log("Successfully posted to " + url);
                     }

--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -37,7 +37,7 @@ namespace mixpanel
         internal static void ReturnValue(Value v)
         {
             if (v == null || _valuePool.Count >= PoolCapacity) return;
-            v.OnRecycle();
+            v.ResetForPool();
             _valuePool.Push(v);
         }
 
@@ -49,6 +49,7 @@ namespace mixpanel
         private static bool _fullyInitialized = false;
         private static bool _isFlushCoroutineRunning = false;
         private static bool _isInitializing = false;  // Guard against concurrent initialization
+        private static bool _isFlushing = false;       // Guard against overlapping flushes
 
         // When MIXPANEL_DISABLE_AUTO_INIT is defined, the BeforeSceneLoad hook is compiled out
         // entirely — zero boot-time cost. Use Mixpanel.Init() to initialize manually.
@@ -164,6 +165,7 @@ namespace mixpanel
             _fullyInitialized = false;  // Reset initialization state
             _isFlushCoroutineRunning = false;  // Reset coroutine flag
             _isInitializing = false;  // Reset initialization guard
+            _isFlushing = false;       // Reset flush guard
             _autoTrackProperties = null;  // Reset auto-properties cache
             _autoEngageProperties = null; // Reset auto-properties cache
             Metadata.ResetSession();  // Clear session state
@@ -262,15 +264,32 @@ namespace mixpanel
 
         internal void DoFlush(Action<bool> onFlushComplete = null)
         {
-            int coroutinesCount = 2; // Number of coroutines to wait for
-            bool overallSuccess = true;
+            // Reject re-entrant flushes. With the storage layer's drain-and-reset
+            // optimization, two overlapping flushes that both dequeue the same
+            // start index range could race: flush A drains + resets the counter,
+            // a new Track() reuses Event0, then flush B's delete-by-key wipes
+            // the freshly enqueued event. The flag is reset when both per-type
+            // coroutines (EVENTS + PEOPLE) finish.
+            if (_isFlushing)
+            {
+                Mixpanel.Log("Flush already in progress; ignoring re-entrant call");
+                onFlushComplete?.Invoke(false);
+                return;
+            }
+            _isFlushing = true;
 
-            Action<bool> onComplete = onFlushComplete != null ?
-                new Action<bool>(success => {
-                    overallSuccess &= success;
-                    CheckCompletion(onFlushComplete, ref coroutinesCount, overallSuccess);
-                })
-                : (Action<bool>)null;
+            int coroutinesRemaining = 2;
+            bool overallSuccess = true;
+            Action<bool> onComplete = success =>
+            {
+                overallSuccess &= success;
+                coroutinesRemaining--;
+                if (coroutinesRemaining == 0)
+                {
+                    _isFlushing = false;
+                    onFlushComplete?.Invoke(overallSuccess);
+                }
+            };
             StartCoroutine(SendData(MixpanelStorage.FlushType.EVENTS, onComplete));
             StartCoroutine(SendData(MixpanelStorage.FlushType.PEOPLE, onComplete));
         }
@@ -319,18 +338,6 @@ namespace mixpanel
             }
 
             onComplete?.Invoke(true);
-        }
-
-        private void CheckCompletion(Action<bool> onFlushComplete, ref int coroutinesCount, bool overallSuccess)
-        {
-            // Decrease the counter
-            coroutinesCount--;
-
-            // If all coroutines are finished, invoke the onFlushComplete callback
-            if (coroutinesCount == 0)
-            {
-                onFlushComplete?.Invoke(overallSuccess);
-            }
         }
 
         private IEnumerator SendHttpEvent(string eventName, string apiToken, string distinctId, string properties, bool updatePeople)

--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -4,12 +4,6 @@ using System.Collections.Generic;
 using System.Text;
 using UnityEngine;
 using UnityEngine.Networking;
-using UnityEngine.Profiling;
-using System.Threading;
-using Unity.Jobs;
-using Unity.Collections;
-using System.Net;
-using System.Net.Http;
 
 #if UNITY_IOS
 using UnityEngine.iOS;
@@ -25,6 +19,29 @@ namespace mixpanel
         private static int _retryCount = 0;
         private static DateTime _retryTime;
 
+        #region ValuePool
+
+        private const int PoolCapacity = 16;
+        private static readonly Stack<Value> _valuePool = new Stack<Value>(PoolCapacity);
+
+        internal static Value RentValue()
+        {
+            if (_valuePool.Count > 0)
+            {
+                return _valuePool.Pop();
+            }
+            return new Value();
+        }
+
+        internal static void ReturnValue(Value v)
+        {
+            if (v == null || _valuePool.Count >= PoolCapacity) return;
+            v.OnRecycle();
+            _valuePool.Push(v);
+        }
+
+        #endregion
+
         #region Singleton
 
         private static Controller _instance;
@@ -32,6 +49,10 @@ namespace mixpanel
         private static bool _isFlushCoroutineRunning = false;
         private static bool _isInitializing = false;  // Guard against concurrent initialization
 
+        // When MIXPANEL_DISABLE_AUTO_INIT is defined, the BeforeSceneLoad hook is compiled out
+        // entirely — zero boot-time cost. Use Mixpanel.Init() to initialize manually.
+        // This is the recommended approach when ManualInitialization is always enabled.
+        #if !MIXPANEL_DISABLE_AUTO_INIT
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void InitializeBeforeSceneLoad()
         {
@@ -39,13 +60,7 @@ namespace mixpanel
             if (Config.ManualInitialization) return;
             Initialize();
         }
-
-        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.AfterSceneLoad)]
-        private static void InitializeAfterSceneLoad()
-        {
-            // Formerly initialized auto properties here; now handled synchronously in Initialize()
-            // Kept as placeholder for potential future use
-        }
+        #endif
 
         internal static void Initialize() {
             // Guard against concurrent initialization calls
@@ -74,14 +89,14 @@ namespace mixpanel
                 // 2. Migrate v1 data if needed (sets DistinctId and IsTracking from old SDK)
                 instance.MigrateFrom1To2();
 
-                // 3. Initialize auto properties synchronously to ensure they're ready for first event
+                #if !MIXPANEL_DISABLE_AUTO_INIT
+                // Eagerly initialize auto properties and preload persisted properties
+                // so the first Track() call has no surprise disk I/O or SystemInfo queries.
+                // Skipped when MIXPANEL_DISABLE_AUTO_INIT is defined — all lazy-load on first use.
                 GetEventsDefaultProperties();
                 GetEngageDefaultProperties();
-
-                // 4. Eagerly load persisted properties to ensure consistent Track() performance
-                // This prevents lazy-loading with disk I/O when Track() is called immediately after Init()
-                // Moving the I/O cost from first Track() to Init() for predictable performance
                 PreloadPersistedProperties();
+                #endif
 
                 // Note: Flush coroutine will be started in Start() to follow Unity lifecycle best practices
                 // and prevent duplicate coroutines if initialization partially fails
@@ -89,7 +104,7 @@ namespace mixpanel
                 // Mark as fully initialized
                 _fullyInitialized = true;
 
-                Mixpanel.Log($"Mixpanel fully initialized (synchronous)");
+                Mixpanel.Log($"Mixpanel initialized");
             }
             catch (Exception e) {
                 Mixpanel.LogError($"Error during Mixpanel initialization: {e}");
@@ -205,12 +220,11 @@ namespace mixpanel
                     // Migrate if not already done
                     MigrateFrom1To2();
 
-                    // Initialize auto properties
+                    #if !MIXPANEL_DISABLE_AUTO_INIT
                     GetEventsDefaultProperties();
                     GetEngageDefaultProperties();
-
-                    // Preload persisted properties
                     PreloadPersistedProperties();
+                    #endif
 
                     // Mark as initialized
                     _fullyInitialized = true;
@@ -269,12 +283,11 @@ namespace mixpanel
             }
 
             string url = (flushType == MixpanelStorage.FlushType.EVENTS) ? Config.TrackUrl : Config.EngageUrl;
-            Value batch = MixpanelStorage.DequeueBatchTrackingData(flushType, Config.BatchSize);
+            MixpanelStorage.StoredBatch batch = MixpanelStorage.DequeueBatchTrackingDataRaw(flushType, Config.BatchSize);
             while (batch.Count > 0) {
                 Dictionary<string, string> form = new Dictionary<string, string>();
-                String payload = batch.ToString();
-                form.Add("data", payload);
-                Mixpanel.Log("Sending batch of data: " + payload);
+                form.Add("data", batch.Payload);
+                Mixpanel.Log("Sending batch of data: " + batch.Payload);
                 using (UnityWebRequest request = UnityWebRequest.Post(url, form))
                 {
                     yield return request.SendWebRequest();
@@ -298,7 +311,7 @@ namespace mixpanel
                     {
                         _retryCount = 0;
                         MixpanelStorage.DeleteBatchTrackingData(batch);
-                        batch = MixpanelStorage.DequeueBatchTrackingData(flushType, Config.BatchSize);
+                        batch = MixpanelStorage.DequeueBatchTrackingDataRaw(flushType, Config.BatchSize);
                         Mixpanel.Log("Successfully posted to " + url);
                     }
                 }
@@ -434,22 +447,6 @@ namespace mixpanel
             return _autoEngageProperties;
         }
 
-        private static void PreloadPersistedProperties() {
-            // Eagerly load all persisted properties from disk into memory cache
-            // This prevents lazy-loading with disk I/O during the first Track() call
-            // Each property getter will check if cached, and if not, load from PlayerPreferences
-            try {
-                _ = MixpanelStorage.SuperProperties;   // Force load + cache
-                _ = MixpanelStorage.OnceProperties;    // Force load + cache
-                _ = MixpanelStorage.TimedEvents;       // Force load + cache
-                Mixpanel.Log($"Preloaded persisted properties from storage");
-            }
-            catch (Exception e) {
-                // Non-critical failure - properties will lazy-load on first use
-                Mixpanel.LogError($"Failed to preload persisted properties: {e}");
-            }
-        }
-
         private static Value GetEventsDefaultProperties()
         {
             if (_autoTrackProperties == null) {
@@ -479,6 +476,21 @@ namespace mixpanel
             return _autoTrackProperties;
         }
 
+        #if !MIXPANEL_DISABLE_AUTO_INIT
+        private static void PreloadPersistedProperties() {
+            try {
+                _ = MixpanelStorage.SuperProperties;
+                _ = MixpanelStorage.OnceProperties;
+                _ = MixpanelStorage.TimedEvents;
+                Mixpanel.Log($"Preloaded persisted properties from storage");
+            }
+            catch (Exception e) {
+                // Non-critical failure - properties will lazy-load on first use
+                Mixpanel.LogError($"Failed to preload persisted properties: {e}");
+            }
+        }
+        #endif
+
         internal static void DoTrack(string eventName, Value properties)
         {
             if (!MixpanelStorage.IsTracking) return;
@@ -499,13 +511,14 @@ namespace mixpanel
             properties["distinct_id"] = MixpanelStorage.DistinctId;
             properties["time"] = Util.CurrentTimeInMilliseconds();
 
-            Value data = new Value();
+            Value data = RentValue();
 
             data["event"] = eventName;
             data["properties"] = properties;
             data["$mp_metadata"] = Metadata.GetEventMetadata();
 
             MixpanelStorage.EnqueueTrackingData(data, MixpanelStorage.FlushType.EVENTS);
+            ReturnValue(data);
         }
 
         internal static void DoEngage(Value properties)

--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -22,6 +22,7 @@ namespace mixpanel
         #region ValuePool
 
         private const int PoolCapacity = 16;
+        // Unity SDK calls run on the main thread; this pool is intentionally not synchronized.
         private static readonly Stack<Value> _valuePool = new Stack<Value>(PoolCapacity);
 
         internal static Value RentValue()
@@ -529,6 +530,8 @@ namespace mixpanel
             properties["$time"] = Util.CurrentTimeInMilliseconds();
             properties["$mp_metadata"] = Metadata.GetPeopleMetadata();
 
+            // Unlike DoTrack, people properties are already the payload, so there is
+            // no wrapper Value to rent or return here.
             MixpanelStorage.EnqueueTrackingData(properties, MixpanelStorage.FlushType.PEOPLE);
         }
 

--- a/Mixpanel/Controller.cs
+++ b/Mixpanel/Controller.cs
@@ -503,10 +503,12 @@ namespace mixpanel
             properties.Merge(MixpanelStorage.OnceProperties);
             properties.Merge(MixpanelStorage.SuperProperties);
             Value startTime;
-            if (MixpanelStorage.TimedEvents.TryGetValue(eventName, out startTime))
+            Value timedEvents = MixpanelStorage.TimedEvents;
+            if (timedEvents.TryGetValue(eventName, out startTime))
             {
                 properties["$duration"] = Util.CurrentTimeInSeconds() - (double)startTime;
-                MixpanelStorage.TimedEvents.Remove(eventName);
+                timedEvents.Remove(eventName);
+                MixpanelStorage.TimedEvents = timedEvents;
             }
             properties["token"] = MixpanelSettings.Instance.Token;
             properties["distinct_id"] = MixpanelStorage.DistinctId;

--- a/Mixpanel/Extensions.cs
+++ b/Mixpanel/Extensions.cs
@@ -1,16 +1,8 @@
-using System.Collections.Generic;
-using System.Linq;
-
 namespace mixpanel
 {
+    // Intentionally empty — previously contained an unused LINQ-based Batch extension.
+    // Kept to preserve the .meta file reference in Unity.
     internal static class Extensions
     {
-        internal static IEnumerable<IEnumerable<T>> Batch<T>(this IEnumerable<T> items, int maxItems)
-        {
-            return items
-                .Select((item, inx) => new { item, inx })
-                .GroupBy(x => x.inx / maxItems)
-                .Select(g => g.Select(x => x.item));
-        }
     }
 }

--- a/Mixpanel/MixpanelAPI.cs
+++ b/Mixpanel/MixpanelAPI.cs
@@ -168,7 +168,7 @@ namespace mixpanel
         {
             if (!IsInitialized()) return;
             Value properties = MixpanelStorage.OnceProperties;
-            if (properties[key].IsNull) {
+            if (!properties.ContainsKey(key)) {
                 properties[key] = value;
                 MixpanelStorage.OnceProperties = properties;
             }

--- a/Mixpanel/MixpanelSettings.cs
+++ b/Mixpanel/MixpanelSettings.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Linq;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -71,11 +70,19 @@ namespace mixpanel
 
         private static MixpanelSettings FindOrCreateInstance()
         {
-            MixpanelSettings instance = null;
-            instance = instance ? null : Resources.Load<MixpanelSettings>("Mixpanel");
-            instance = instance ? instance : Resources.LoadAll<MixpanelSettings>(string.Empty).FirstOrDefault();
-            instance = instance ? instance : CreateAndSave<MixpanelSettings>();
-            if (instance == null) throw new Exception("Could not find or create settings for Mixpanel");
+            MixpanelSettings instance = Resources.Load<MixpanelSettings>("Mixpanel");
+            if (instance == null)
+            {
+                // Preserve compatibility with existing projects that stored the asset
+                // elsewhere under Resources with a different name.
+                MixpanelSettings[] existingInstances = Resources.LoadAll<MixpanelSettings>(string.Empty);
+                if (existingInstances != null && existingInstances.Length > 0)
+                    instance = existingInstances[0];
+            }
+            if (instance == null)
+                instance = CreateAndSave<MixpanelSettings>();
+            if (instance == null)
+                throw new Exception("Could not find or create settings for Mixpanel");
             return instance;
         }
 

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -45,10 +45,39 @@ namespace mixpanel
             int valueTypeIndex = startIndex + legacyPrefix.Length;
             if (valueTypeIndex >= json.Length) return false;
 
-            // JsonUtility emits ValueTypes as an integer; Value.ToString() may emit
-            // a user key named "_valueType".
+            // JsonUtility emits ValueTypes as an integer, but a user payload may
+            // also legitimately start with a top-level "_valueType" numeric
+            // property. Require additional JsonUtility backing fields before
+            // treating stored data as legacy format.
             char valueType = json[valueTypeIndex];
-            return valueType >= '0' && valueType <= '9';
+            return valueType >= '0' && valueType <= '9'
+                && HasJsonUtilityField(json, startIndex, "\"_dataType\":")
+                && (HasJsonUtilityField(json, startIndex, "\"_arrayData\":")
+                    || (HasJsonUtilityField(json, startIndex, "\"_containerKeys\":")
+                        && HasJsonUtilityField(json, startIndex, "\"_containerValues\":")));
+        }
+
+        private static bool HasJsonUtilityField(string json, int startIndex, string field)
+        {
+            return json.IndexOf(field, startIndex, StringComparison.Ordinal) >= 0;
+        }
+
+        private static void EnsureStoredPayloadIsObjectJson(string json)
+        {
+            int startIndex = 0;
+            while (startIndex < json.Length && char.IsWhiteSpace(json[startIndex]))
+            {
+                startIndex++;
+            }
+
+            int endIndex = json.Length - 1;
+            while (endIndex >= startIndex && char.IsWhiteSpace(json[endIndex]))
+            {
+                endIndex--;
+            }
+
+            if (startIndex > endIndex || json[startIndex] != '{' || json[endIndex] != '}')
+                throw new FormatException("Stored tracking payload is not a JSON object.");
         }
 
         // Deserializes stored Value data, accepting both JsonUtility-backed data and
@@ -68,8 +97,14 @@ namespace mixpanel
 
         private static string NormalizeStoredPayload(string json)
         {
-            if (string.IsNullOrEmpty(json)) return "null";
-            return IsLegacySerializedValue(json) ? JsonUtility.FromJson<Value>(json).ToString() : json;
+            if (string.IsNullOrWhiteSpace(json))
+                throw new FormatException("Stored tracking payload is empty.");
+
+            string normalizedPayload = IsLegacySerializedValue(json)
+                ? JsonUtility.FromJson<Value>(json).ToString()
+                : json;
+            EnsureStoredPayloadIsObjectJson(normalizedPayload);
+            return normalizedPayload;
         }
         #region Preferences
         private static IPreferences PreferencesSource = new PlayerPreferences();
@@ -244,7 +279,7 @@ namespace mixpanel
                         trackingKeys.Add(trackingKey);
                     }
                     catch (Exception e) {
-                        Mixpanel.LogError($"There was an error processing '{trackingKey}' from the internal object pool: " + e);
+                        Mixpanel.LogError($"There was an error processing stored tracking payload '{trackingKey}': " + e);
                         PreferencesSource.DeleteKey(trackingKey);
 
                         if (trackingKeys.Count == 0) {

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -1,21 +1,47 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Text;
 using UnityEngine;
-using System.Net;
-using System.Net.Http;
-using System.Web;
-using UnityEngine.Networking;
-using Unity.Jobs;
-using Unity.Collections;
 
 namespace mixpanel
 {
     public static class MixpanelStorage
     {
+        internal sealed class StoredBatch
+        {
+            internal readonly List<string> TrackingKeys;
+            internal readonly string Payload;
+
+            internal int Count => TrackingKeys.Count;
+
+            internal StoredBatch(List<string> trackingKeys, string payload)
+            {
+                TrackingKeys = trackingKeys;
+                Payload = payload;
+            }
+        }
+
+        private static bool IsLegacySerializedValue(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return false;
+            return json.TrimStart().StartsWith("{\"_valueType\":", StringComparison.Ordinal);
+        }
+
+        // Deserializes stored Value data, accepting both JsonUtility-backed data and
+        // the newer Value.ToString() format during migration.
+        private static Value DeserializeStored(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return new Value();
+            if (IsLegacySerializedValue(json))
+                return JsonUtility.FromJson<Value>(json);
+            return Value.Deserialize(json);
+        }
+
+        private static string NormalizeStoredPayload(string json)
+        {
+            if (string.IsNullOrEmpty(json)) return "null";
+            return IsLegacySerializedValue(json) ? JsonUtility.FromJson<Value>(json).ToString() : json;
+        }
         #region Preferences
         private static IPreferences PreferencesSource = new PlayerPreferences();
 
@@ -83,13 +109,59 @@ namespace mixpanel
             PEOPLE,
         }
 
+        private static string TrackingKey(FlushType flushType, int dataIndex)
+        {
+            return (flushType == FlushType.EVENTS) ? "Event" + dataIndex.ToString() : "People" + dataIndex.ToString();
+        }
+
+        private static string TrackingIdKey(FlushType flushType)
+        {
+            return (flushType == FlushType.EVENTS) ? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
+        }
+
+        private static string StartIndexKey(FlushType flushType)
+        {
+            return (flushType == FlushType.EVENTS) ? EventStartIndexName : PeopleStartIndexName;
+        }
+
+        private static int NextTrackingId(FlushType flushType)
+        {
+            return (flushType == FlushType.EVENTS) ? EventAutoIncrementingID() : PeopleAutoIncrementingID();
+        }
+
+        private static int CurrentStartIndex(FlushType flushType)
+        {
+            return (flushType == FlushType.EVENTS) ? EventStartIndex() : PeopleStartIndex();
+        }
+
+        private static int AdvanceStartIndex(FlushType flushType, int startIndex, int maxIndex)
+        {
+            while (startIndex <= maxIndex && !PreferencesSource.HasKey(TrackingKey(flushType, startIndex)))
+            {
+                startIndex++;
+            }
+
+            return startIndex;
+        }
+
+        private static int NormalizeStartIndex(FlushType flushType)
+        {
+            int oldStartIndex = CurrentStartIndex(flushType);
+            int newStartIndex = AdvanceStartIndex(flushType, oldStartIndex, NextTrackingId(flushType) - 1);
+            if (newStartIndex != oldStartIndex)
+            {
+                PreferencesSource.SetInt(StartIndexKey(flushType), newStartIndex);
+            }
+
+            return newStartIndex;
+        }
+
         internal static void EnqueueTrackingData(Value data, FlushType flushType)
         {
-            int eventId = EventAutoIncrementingID();
-            int peopleId = PeopleAutoIncrementingID();
-            String trackingKey = (flushType == FlushType.EVENTS)? "Event" + eventId.ToString() : "People" + peopleId.ToString();
+            int trackingDataId = NextTrackingId(flushType);
+            String trackingKey = TrackingKey(flushType, trackingDataId);
             data["id"] = trackingKey;
-            PreferencesSource.SetString(trackingKey, JsonUtility.ToJson(data));
+            PreferencesSource.SetString(trackingKey, data.ToString());
             IncreaseTrackingDataID(flushType);
         }
 
@@ -115,39 +187,46 @@ namespace mixpanel
 
         private static void IncreaseTrackingDataID(FlushType flushType)
         {
-            int id = (flushType == FlushType.EVENTS)? EventAutoIncrementingID() : PeopleAutoIncrementingID();
+            int id = NextTrackingId(flushType);
             id += 1;
-            String trackingIdKey = (flushType == FlushType.EVENTS)? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
-            PreferencesSource.SetInt(trackingIdKey, id);
+            PreferencesSource.SetInt(TrackingIdKey(flushType), id);
         }
 
-        internal static Value DequeueBatchTrackingData(FlushType flushType, int batchSize)
+        internal static StoredBatch DequeueBatchTrackingDataRaw(FlushType flushType, int batchSize)
         {
-            Value batch = Value.Array;
-            string startIndexKey = (flushType == FlushType.EVENTS) ? EventStartIndexName : PeopleStartIndexName;
-            int oldStartIndex = (flushType == FlushType.EVENTS) ? EventStartIndex() : PeopleStartIndex();
+            List<string> trackingKeys = new List<string>(Math.Max(batchSize, 0));
+            StringBuilder payload = new StringBuilder(256);
+            payload.Append('[');
+
+            string startIndexKey = StartIndexKey(flushType);
+            int oldStartIndex = NormalizeStartIndex(flushType);
             int newStartIndex = oldStartIndex;
             int dataIndex = oldStartIndex;
-            int maxIndex = (flushType == FlushType.EVENTS) ? EventAutoIncrementingID() - 1 : PeopleAutoIncrementingID() - 1;
-            while (batch.Count < batchSize && dataIndex <= maxIndex) {
-                String trackingKey = (flushType == FlushType.EVENTS) ? "Event" + dataIndex.ToString() : "People" + dataIndex.ToString();
+            int maxIndex = NextTrackingId(flushType) - 1;
+            bool wroteItem = false;
+            while (trackingKeys.Count < batchSize && dataIndex <= maxIndex) {
+                String trackingKey = TrackingKey(flushType, dataIndex);
                 if (PreferencesSource.HasKey(trackingKey)) {
                     try {
-                        batch.Add(JsonUtility.FromJson<Value>(PreferencesSource.GetString(trackingKey)));
+                        string normalizedPayload = NormalizeStoredPayload(PreferencesSource.GetString(trackingKey));
+                        if (wroteItem) payload.Append(", ");
+                        payload.Append(normalizedPayload);
+                        wroteItem = true;
+                        trackingKeys.Add(trackingKey);
                     }
                     catch (Exception e) {
                         Mixpanel.LogError($"There was an error processing '{trackingKey}' from the internal object pool: " + e);
                         PreferencesSource.DeleteKey(trackingKey);
 
-                        if (batch.Count == 0) {
+                        if (trackingKeys.Count == 0) {
                             // Only update if we didn't find a key prior to deleting this key, since the prior key would be a lower valid index.
-                            newStartIndex = Math.Min(dataIndex + 1, maxIndex);
+                            newStartIndex = Math.Min(dataIndex + 1, maxIndex + 1);
                         }
                     }
                 }
-                else if (batch.Count == 0) {
+                else if (trackingKeys.Count == 0) {
                     // Keep updating the start index as long as we haven't found anything for our batch yet -- we're looking for the minimum index.
-                    newStartIndex = Math.Min(dataIndex + 1, maxIndex);
+                    newStartIndex = Math.Min(dataIndex + 1, maxIndex + 1);
                 }
                 dataIndex++;
             }
@@ -156,24 +235,25 @@ namespace mixpanel
                 PreferencesSource.SetInt(startIndexKey, newStartIndex);
             }
 
-            return batch;
+            payload.Append(']');
+            return new StoredBatch(trackingKeys, payload.ToString());
         }
 
         internal static void DeleteBatchTrackingData(FlushType flushType, int batchSize)
         {
             int deletedCount = 0;
-            string startIndexKey = (flushType == FlushType.EVENTS) ? EventStartIndexName : PeopleStartIndexName;
-            int oldStartIndex = (flushType == FlushType.EVENTS) ? EventStartIndex() : PeopleStartIndex();
+            string startIndexKey = StartIndexKey(flushType);
+            int oldStartIndex = CurrentStartIndex(flushType);
             int newStartIndex = oldStartIndex;
             int dataIndex = oldStartIndex;
-            int maxIndex = (flushType == FlushType.EVENTS) ? EventAutoIncrementingID() - 1 : PeopleAutoIncrementingID() - 1;
+            int maxIndex = NextTrackingId(flushType) - 1;
             while (deletedCount < batchSize && dataIndex <= maxIndex) {
-                String trackingKey = (flushType == FlushType.EVENTS) ? "Event" + dataIndex.ToString() : "People" + dataIndex.ToString();
+                String trackingKey = TrackingKey(flushType, dataIndex);
                 if (PreferencesSource.HasKey(trackingKey)) {
                     PreferencesSource.DeleteKey(trackingKey);
                     deletedCount++;
                 }
-                newStartIndex = Math.Min(dataIndex + 1, maxIndex);
+                newStartIndex = Math.Min(dataIndex + 1, maxIndex + 1);
                 dataIndex++;
             }
 
@@ -182,7 +262,7 @@ namespace mixpanel
                 // For performance reasons, reset the tracking data ID to 0 if all data stored in PlayerPrefs has been deleted.
                 // Otherwise, there can be a large number of string concatenation and PreferencesSource.Haskey calls (in extreme cases, 100K+).
                 // See https://github.com/mixpanel/mixpanel-unity/pull/152 for context
-                string idKey = (flushType == FlushType.EVENTS) ? EventAutoIncrementingIdName : PeopleAutoIncrementingIdName;
+                string idKey = TrackingIdKey(flushType);
                 PreferencesSource.SetInt(idKey, 0);
                 PreferencesSource.SetInt(startIndexKey, 0);
             }
@@ -192,11 +272,10 @@ namespace mixpanel
             }
         }
 
-        internal static void DeleteBatchTrackingData(Value batch) {
-            foreach(Value data in batch) {
-                String id = data["id"];
-                if (id != null && PreferencesSource.HasKey(id)) {
-                    PreferencesSource.DeleteKey(id);
+        internal static void DeleteBatchTrackingData(StoredBatch batch) {
+            foreach (string trackingKey in batch.TrackingKeys) {
+                if (PreferencesSource.HasKey(trackingKey)) {
+                    PreferencesSource.DeleteKey(trackingKey);
                 }
             }
         }
@@ -245,8 +324,7 @@ namespace mixpanel
                 if (!PreferencesSource.HasKey(OncePropertiesName)) OnceProperties = new Value();
                 else
                 {
-                    _onceProperties = new Value();
-                    JsonUtility.FromJsonOverwrite(PreferencesSource.GetString(OncePropertiesName), _onceProperties);
+                    _onceProperties = DeserializeStored(PreferencesSource.GetString(OncePropertiesName));
                 }
                 return _onceProperties;
             }
@@ -280,8 +358,7 @@ namespace mixpanel
                 if (!PreferencesSource.HasKey(SuperPropertiesName)) SuperProperties = new Value();
                 else
                 {
-                    _superProperties = new Value();
-                    JsonUtility.FromJsonOverwrite(PreferencesSource.GetString(SuperPropertiesName), _superProperties);
+                    _superProperties = DeserializeStored(PreferencesSource.GetString(SuperPropertiesName));
                 }
                 return _superProperties;
             }
@@ -315,8 +392,7 @@ namespace mixpanel
                 if (!PreferencesSource.HasKey(TimedEventsName)) TimedEvents = new Value();
                 else
                 {
-                    _timedEvents = new Value();
-                    JsonUtility.FromJsonOverwrite(PreferencesSource.GetString(TimedEventsName), _timedEvents);
+                    _timedEvents = DeserializeStored(PreferencesSource.GetString(TimedEventsName));
                 }
                 return _timedEvents;
             }

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -24,7 +24,31 @@ namespace mixpanel
         private static bool IsLegacySerializedValue(string json)
         {
             if (string.IsNullOrEmpty(json)) return false;
-            return json.TrimStart().StartsWith("{\"_valueType\":", StringComparison.Ordinal);
+
+            const string legacyPrefix = "{\"_valueType\":";
+            int startIndex = 0;
+            while (startIndex < json.Length && char.IsWhiteSpace(json[startIndex]))
+            {
+                startIndex++;
+            }
+
+            if (startIndex > json.Length - legacyPrefix.Length) return false;
+            bool hasLegacyPrefix = string.Compare(
+                json,
+                startIndex,
+                legacyPrefix,
+                0,
+                legacyPrefix.Length,
+                StringComparison.Ordinal) == 0;
+            if (!hasLegacyPrefix) return false;
+
+            int valueTypeIndex = startIndex + legacyPrefix.Length;
+            if (valueTypeIndex >= json.Length) return false;
+
+            // JsonUtility emits ValueTypes as an integer; Value.ToString() may emit
+            // a user key named "_valueType".
+            char valueType = json[valueTypeIndex];
+            return valueType >= '0' && valueType <= '9';
         }
 
         // Deserializes stored Value data, accepting both JsonUtility-backed data and
@@ -35,6 +59,11 @@ namespace mixpanel
             if (IsLegacySerializedValue(json))
                 return JsonUtility.FromJson<Value>(json);
             return Value.Deserialize(json);
+        }
+
+        private static string SerializeStored(Value value)
+        {
+            return value == null ? "null" : value.ToString();
         }
 
         private static string NormalizeStoredPayload(string json)
@@ -161,7 +190,7 @@ namespace mixpanel
             int trackingDataId = NextTrackingId(flushType);
             String trackingKey = TrackingKey(flushType, trackingDataId);
             data["id"] = trackingKey;
-            PreferencesSource.SetString(trackingKey, data.ToString());
+            PreferencesSource.SetString(trackingKey, SerializeStored(data));
             IncreaseTrackingDataID(flushType);
         }
 
@@ -349,7 +378,7 @@ namespace mixpanel
             set
             {
                 _onceProperties = value;
-                PreferencesSource.SetString(OncePropertiesName, JsonUtility.ToJson(_onceProperties));
+                PreferencesSource.SetString(OncePropertiesName, SerializeStored(_onceProperties));
             }
         }
 
@@ -383,7 +412,7 @@ namespace mixpanel
             set
             {
                 _superProperties = value;
-                PreferencesSource.SetString(SuperPropertiesName, JsonUtility.ToJson(_superProperties));
+                PreferencesSource.SetString(SuperPropertiesName, SerializeStored(_superProperties));
             }
         }
 
@@ -417,7 +446,7 @@ namespace mixpanel
             set
             {
                 _timedEvents = value;
-                PreferencesSource.SetString(TimedEventsName, JsonUtility.ToJson(_timedEvents));
+                PreferencesSource.SetString(TimedEventsName, SerializeStored(_timedEvents));
             }
         }
 

--- a/Mixpanel/Storage.cs
+++ b/Mixpanel/Storage.cs
@@ -272,11 +272,29 @@ namespace mixpanel
             }
         }
 
-        internal static void DeleteBatchTrackingData(StoredBatch batch) {
+        internal static void DeleteBatchTrackingData(FlushType flushType, StoredBatch batch)
+        {
+            if (batch == null || batch.Count == 0) return;
+
             foreach (string trackingKey in batch.TrackingKeys) {
                 if (PreferencesSource.HasKey(trackingKey)) {
                     PreferencesSource.DeleteKey(trackingKey);
                 }
+            }
+
+            string startIndexKey = StartIndexKey(flushType);
+            int oldStartIndex = CurrentStartIndex(flushType);
+            int maxIndex = NextTrackingId(flushType) - 1;
+            int newStartIndex = AdvanceStartIndex(flushType, oldStartIndex, maxIndex);
+
+            if (newStartIndex > maxIndex) {
+                // Reset the ids when the queue drains so future flushes do not
+                // keep scanning sparse, ever-growing PlayerPrefs keys.
+                PreferencesSource.SetInt(TrackingIdKey(flushType), 0);
+                PreferencesSource.SetInt(startIndexKey, 0);
+            }
+            else if (newStartIndex != oldStartIndex) {
+                PreferencesSource.SetInt(startIndexKey, newStartIndex);
             }
         }
 

--- a/Mixpanel/Value.cs
+++ b/Mixpanel/Value.cs
@@ -48,14 +48,26 @@ namespace mixpanel
         [SerializeField] private bool _bool;
         [SerializeField] private double _number;
 
-        [NonSerialized]
-        private List<Value> _array = new List<Value>(50);
+        // Lazy-initialized backing fields — null until first use.
+        // All access goes through the _array/_container properties below.
+        [NonSerialized] private List<Value> _arrayBacking;
         [SerializeField] private string[] _arrayData;
 
-        [NonSerialized]
-        private Dictionary<string, Value> _container = new Dictionary<string, Value>(5);
+        [NonSerialized] private Dictionary<string, Value> _containerBacking;
         [SerializeField] private string[] _containerKeys;
         [SerializeField] private string[] _containerValues;
+
+        private List<Value> _array {
+            get => _arrayBacking ?? (_arrayBacking = new List<Value>());
+            set => _arrayBacking = value;
+        }
+
+        private Dictionary<string, Value> _container {
+            get => _containerBacking ?? (_containerBacking = new Dictionary<string, Value>());
+            set => _containerBacking = value;
+        }
+
+        [ThreadStatic] private static StringBuilder _sharedBuilder;
 
         public bool IsNull => _valueType == ValueTypes.NULL;
         public bool IsArray => _valueType == ValueTypes.ARRAY;
@@ -63,12 +75,14 @@ namespace mixpanel
 
         public void OnRecycle()
         {
+            _valueType = ValueTypes.OBJECT;
+            _dataType = DataTypes.UNDEFINED;
             _string = "";
             _bool = false;
             _number = 0;
-            _array.Clear();
+            _arrayBacking = null;
             _arrayData = null;
-            _container.Clear();
+            _containerBacking = null;
             _containerKeys = null;
             _containerValues = null;
         }
@@ -119,13 +133,11 @@ namespace mixpanel
                 case ValueTypes.NUMBER:
                     return _number.ToString(CultureInfo.InvariantCulture);
                 case ValueTypes.ARRAY:
-                    StringWriter arrayWriter = new StringWriter();
-                    Write(arrayWriter);
-                    return arrayWriter.ToString();
                 case ValueTypes.OBJECT:
-                    StringWriter containerWriter = new StringWriter();
-                    Write(containerWriter);
-                    return containerWriter.ToString();
+                    var sb = _sharedBuilder ?? (_sharedBuilder = new StringBuilder(256));
+                    sb.Length = 0;
+                    Write(sb);
+                    return sb.ToString();
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -589,257 +601,236 @@ namespace mixpanel
         #region ToJsonType
         
         public static implicit operator Value(string value) => new Value(value);
-        public static implicit operator Value(string[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<string> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(string[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<string> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(bool value) => new Value(value);
-        public static implicit operator Value(bool[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<bool> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(bool[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<bool> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(float value) => new Value((double)(decimal)value);
-        public static implicit operator Value(float[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<float> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(float[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<float> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(double value) => new Value(value);
-        public static implicit operator Value(double[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<double> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(double[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<double> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(decimal value) => new Value((double)value);
-        public static implicit operator Value(decimal[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<decimal> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(decimal[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<decimal> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(short value) => new Value(value);
-        public static implicit operator Value(short[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<short> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(short[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<short> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(int value) => new Value(value);
-        public static implicit operator Value(int[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<int> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(int[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<int> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(long value) => new Value(value);
-        public static implicit operator Value(long[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<long> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(long[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<long> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(ushort value) => new Value(value);
-        public static implicit operator Value(ushort[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<ushort> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(ushort[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<ushort> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(uint value) => new Value(value);
-        public static implicit operator Value(uint[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<uint> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(uint[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<uint> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(ulong value) => new Value(value);
-        public static implicit operator Value(ulong[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<ulong> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(ulong[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<ulong> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(sbyte value) => new Value(value);
-        public static implicit operator Value(sbyte[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<sbyte> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(sbyte[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<sbyte> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(byte value) => new Value(value);
-        public static implicit operator Value(byte[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<byte> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(byte[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<byte> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         
         public static implicit operator Value(Uri value) => new Value(value);
-        public static implicit operator Value(Uri[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Uri> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Uri[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Uri> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Guid value) => new Value(value);
-        public static implicit operator Value(Guid[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Guid> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Guid[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Guid> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(DateTime value) => new Value(value);
-        public static implicit operator Value(DateTime[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<DateTime> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(DateTime[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<DateTime> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(DateTimeOffset value) => new Value(value);
-        public static implicit operator Value(DateTimeOffset[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<DateTimeOffset> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(DateTimeOffset[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<DateTimeOffset> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(TimeSpan value) => new Value(value);
-        public static implicit operator Value(TimeSpan[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<TimeSpan> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(TimeSpan[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<TimeSpan> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Color value) => new Value(value);
-        public static implicit operator Value(Color[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Color> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Color[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Color> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Color32 value) => new Value(value);
-        public static implicit operator Value(Color32[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Color32> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Color32[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Color32> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector2 value) => new Value(value);
-        public static implicit operator Value(Vector2[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Vector2> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Vector2[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector2> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector3 value) => new Value(value);
-        public static implicit operator Value(Vector3[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Vector3> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Vector3[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector3> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector4 value) => new Value(value);
-        public static implicit operator Value(Vector4[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Vector4> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Vector4[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector4> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Quaternion value) => new Value(value);
-        public static implicit operator Value(Quaternion[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Quaternion> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Quaternion[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Quaternion> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Bounds value) => new Value(value);
-        public static implicit operator Value(Bounds[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Bounds> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Bounds[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Bounds> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Rect value) => new Value(value);
-        public static implicit operator Value(Rect[] value) => new Value(System.Array.ConvertAll(value, x => (Value)x));
-        public static implicit operator Value(List<Rect> value) => new Value(System.Array.ConvertAll(value.ToArray(), x => (Value)x));
+        public static implicit operator Value(Rect[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Rect> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         
         #endregion
 
         #region ToOtherTypes
         
         public static implicit operator string(Value value) => value.String;
-        public static implicit operator string[](Value value) => value._array.ConvertAll(x => (string)x).ToArray();
-        public static implicit operator List<string>(Value value) => value._array.ConvertAll(x => (string)x);
+        public static implicit operator string[](Value value) { var r = new string[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (string)value._array[i]; return r; }
+        public static implicit operator List<string>(Value value) { var r = new List<string>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((string)value._array[i]); return r; }
         public static implicit operator bool(Value value) => value.Bool;
-        public static implicit operator bool[](Value value) => value._array.ConvertAll(x => (bool)x).ToArray();
-        public static implicit operator List<bool>(Value value) => value._array.ConvertAll(x => (bool)x);
+        public static implicit operator bool[](Value value) { var r = new bool[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (bool)value._array[i]; return r; }
+        public static implicit operator List<bool>(Value value) { var r = new List<bool>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((bool)value._array[i]); return r; }
         public static implicit operator float(Value value) => (float)value.Number;
-        public static implicit operator float[](Value value) => value._array.ConvertAll(x => (float)x).ToArray();
-        public static implicit operator List<float>(Value value) => value._array.ConvertAll(x => (float)x);
+        public static implicit operator float[](Value value) { var r = new float[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (float)value._array[i]; return r; }
+        public static implicit operator List<float>(Value value) { var r = new List<float>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((float)value._array[i]); return r; }
         public static implicit operator double(Value value) => value.Number;
-        public static implicit operator double[](Value value) => value._array.ConvertAll(x => (double)x).ToArray();
-        public static implicit operator List<double>(Value value) => value._array.ConvertAll(x => (double)x);
+        public static implicit operator double[](Value value) { var r = new double[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (double)value._array[i]; return r; }
+        public static implicit operator List<double>(Value value) { var r = new List<double>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((double)value._array[i]); return r; }
         public static implicit operator decimal(Value value) => (decimal)value.Number;
-        public static implicit operator decimal[](Value value) => value._array.ConvertAll(x => (decimal)x).ToArray();
-        public static implicit operator List<decimal>(Value value) => value._array.ConvertAll(x => (decimal)x);
+        public static implicit operator decimal[](Value value) { var r = new decimal[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (decimal)value._array[i]; return r; }
+        public static implicit operator List<decimal>(Value value) { var r = new List<decimal>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((decimal)value._array[i]); return r; }
         public static implicit operator short(Value value) => (short)value.Number;
-        public static implicit operator short[](Value value) => value._array.ConvertAll(x => (short)x).ToArray();
-        public static implicit operator List<short>(Value value) => value._array.ConvertAll(x => (short)x);
+        public static implicit operator short[](Value value) { var r = new short[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (short)value._array[i]; return r; }
+        public static implicit operator List<short>(Value value) { var r = new List<short>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((short)value._array[i]); return r; }
         public static implicit operator int(Value value) => (int)value.Number;
-        public static implicit operator int[](Value value) => value._array.ConvertAll(x => (int)x).ToArray();
-        public static implicit operator List<int>(Value value) => value._array.ConvertAll(x => (int)x);
+        public static implicit operator int[](Value value) { var r = new int[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (int)value._array[i]; return r; }
+        public static implicit operator List<int>(Value value) { var r = new List<int>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((int)value._array[i]); return r; }
         public static implicit operator long(Value value) => (long)value.Number;
-        public static implicit operator long[](Value value) => value._array.ConvertAll(x => (long)x).ToArray();
-        public static implicit operator List<long>(Value value) => value._array.ConvertAll(x => (long)x);
+        public static implicit operator long[](Value value) { var r = new long[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (long)value._array[i]; return r; }
+        public static implicit operator List<long>(Value value) { var r = new List<long>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((long)value._array[i]); return r; }
         public static implicit operator ushort(Value value) => (ushort)value.Number;
-        public static implicit operator ushort[](Value value) => value._array.ConvertAll(x => (ushort)x).ToArray();
-        public static implicit operator List<ushort>(Value value) => value._array.ConvertAll(x => (ushort)x);
+        public static implicit operator ushort[](Value value) { var r = new ushort[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (ushort)value._array[i]; return r; }
+        public static implicit operator List<ushort>(Value value) { var r = new List<ushort>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((ushort)value._array[i]); return r; }
         public static implicit operator uint(Value value) => (uint)value.Number;
-        public static implicit operator uint[](Value value) => value._array.ConvertAll(x => (uint)x).ToArray();
-        public static implicit operator List<uint>(Value value) => value._array.ConvertAll(x => (uint)x);
+        public static implicit operator uint[](Value value) { var r = new uint[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (uint)value._array[i]; return r; }
+        public static implicit operator List<uint>(Value value) { var r = new List<uint>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((uint)value._array[i]); return r; }
         public static implicit operator ulong(Value value) => (ulong)value.Number;
-        public static implicit operator ulong[](Value value) => value._array.ConvertAll(x => (ulong)x).ToArray();
-        public static implicit operator List<ulong>(Value value) => value._array.ConvertAll(x => (ulong)x);
+        public static implicit operator ulong[](Value value) { var r = new ulong[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (ulong)value._array[i]; return r; }
+        public static implicit operator List<ulong>(Value value) { var r = new List<ulong>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((ulong)value._array[i]); return r; }
         public static implicit operator sbyte(Value value) => (sbyte)value.Number;
-        public static implicit operator sbyte[](Value value) => value._array.ConvertAll(x => (sbyte)x).ToArray();
-        public static implicit operator List<sbyte>(Value value) => value._array.ConvertAll(x => (sbyte)x);
+        public static implicit operator sbyte[](Value value) { var r = new sbyte[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (sbyte)value._array[i]; return r; }
+        public static implicit operator List<sbyte>(Value value) { var r = new List<sbyte>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((sbyte)value._array[i]); return r; }
         public static implicit operator byte(Value value) => (byte)value.Number;
-        public static implicit operator byte[](Value value) => value._array.ConvertAll(x => (byte)x).ToArray();
-        public static implicit operator List<byte>(Value value) => value._array.ConvertAll(x => (byte)x);
+        public static implicit operator byte[](Value value) { var r = new byte[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (byte)value._array[i]; return r; }
+        public static implicit operator List<byte>(Value value) { var r = new List<byte>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((byte)value._array[i]); return r; }
         
         public static implicit operator Uri(Value value) => value.Uri;
-        public static implicit operator Uri[](Value value) => value._array.ConvertAll(x => (Uri)x).ToArray();
-        public static implicit operator List<Uri>(Value value) => value._array.ConvertAll(x => (Uri)x);
+        public static implicit operator Uri[](Value value) { var r = new Uri[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Uri)value._array[i]; return r; }
+        public static implicit operator List<Uri>(Value value) { var r = new List<Uri>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Uri)value._array[i]); return r; }
         public static implicit operator Guid(Value value) => value.Guid;
-        public static implicit operator Guid[](Value value) => value._array.ConvertAll(x => (Guid)x).ToArray();
-        public static implicit operator List<Guid>(Value value) => value._array.ConvertAll(x => (Guid)x);
+        public static implicit operator Guid[](Value value) { var r = new Guid[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Guid)value._array[i]; return r; }
+        public static implicit operator List<Guid>(Value value) { var r = new List<Guid>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Guid)value._array[i]); return r; }
         public static implicit operator DateTime(Value value) => value.DateTime;
-        public static implicit operator DateTime[](Value value) => value._array.ConvertAll(x => (DateTime)x).ToArray();
-        public static implicit operator List<DateTime>(Value value) => value._array.ConvertAll(x => (DateTime)x);
+        public static implicit operator DateTime[](Value value) { var r = new DateTime[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (DateTime)value._array[i]; return r; }
+        public static implicit operator List<DateTime>(Value value) { var r = new List<DateTime>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((DateTime)value._array[i]); return r; }
         public static implicit operator DateTimeOffset(Value value) => value.DateTimeOffset;
-        public static implicit operator DateTimeOffset[](Value value) => value._array.ConvertAll(x => (DateTimeOffset)x).ToArray();
-        public static implicit operator List<DateTimeOffset>(Value value) => value._array.ConvertAll(x => (DateTimeOffset)x);
+        public static implicit operator DateTimeOffset[](Value value) { var r = new DateTimeOffset[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (DateTimeOffset)value._array[i]; return r; }
+        public static implicit operator List<DateTimeOffset>(Value value) { var r = new List<DateTimeOffset>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((DateTimeOffset)value._array[i]); return r; }
         public static implicit operator TimeSpan(Value value) => value.TimeSpan;
-        public static implicit operator TimeSpan[](Value value) => value._array.ConvertAll(x => (TimeSpan)x).ToArray();
-        public static implicit operator List<TimeSpan>(Value value) => value._array.ConvertAll(x => (TimeSpan)x);
+        public static implicit operator TimeSpan[](Value value) { var r = new TimeSpan[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (TimeSpan)value._array[i]; return r; }
+        public static implicit operator List<TimeSpan>(Value value) { var r = new List<TimeSpan>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((TimeSpan)value._array[i]); return r; }
         public static implicit operator Color(Value value) => value.Color;
-        public static implicit operator Color[](Value value) => value._array.ConvertAll(x => (Color)x).ToArray();
-        public static implicit operator List<Color>(Value value) => value._array.ConvertAll(x => (Color)x);
+        public static implicit operator Color[](Value value) { var r = new Color[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Color)value._array[i]; return r; }
+        public static implicit operator List<Color>(Value value) { var r = new List<Color>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Color)value._array[i]); return r; }
         public static implicit operator Color32(Value value) => value.Color32;
-        public static implicit operator Color32[](Value value) => value._array.ConvertAll(x => (Color32)x).ToArray();
-        public static implicit operator List<Color32>(Value value) => value._array.ConvertAll(x => (Color32)x);
+        public static implicit operator Color32[](Value value) { var r = new Color32[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Color32)value._array[i]; return r; }
+        public static implicit operator List<Color32>(Value value) { var r = new List<Color32>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Color32)value._array[i]); return r; }
         public static implicit operator Vector2(Value value) => value.Vector2;
-        public static implicit operator Vector2[](Value value) => value._array.ConvertAll(x => (Vector2)x).ToArray();
-        public static implicit operator List<Vector2>(Value value) => value._array.ConvertAll(x => (Vector2)x);
+        public static implicit operator Vector2[](Value value) { var r = new Vector2[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Vector2)value._array[i]; return r; }
+        public static implicit operator List<Vector2>(Value value) { var r = new List<Vector2>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Vector2)value._array[i]); return r; }
         public static implicit operator Vector3(Value value) => value.Vector3;
-        public static implicit operator Vector3[](Value value) => value._array.ConvertAll(x => (Vector3)x).ToArray();
-        public static implicit operator List<Vector3>(Value value) => value._array.ConvertAll(x => (Vector3)x);
+        public static implicit operator Vector3[](Value value) { var r = new Vector3[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Vector3)value._array[i]; return r; }
+        public static implicit operator List<Vector3>(Value value) { var r = new List<Vector3>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Vector3)value._array[i]); return r; }
         public static implicit operator Vector4(Value value) => value.Vector4;
-        public static implicit operator Vector4[](Value value) => value._array.ConvertAll(x => (Vector4)x).ToArray();
-        public static implicit operator List<Vector4>(Value value) => value._array.ConvertAll(x => (Vector4)x);
+        public static implicit operator Vector4[](Value value) { var r = new Vector4[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Vector4)value._array[i]; return r; }
+        public static implicit operator List<Vector4>(Value value) { var r = new List<Vector4>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Vector4)value._array[i]); return r; }
         public static implicit operator Quaternion(Value value) => value.Quaternion;
-        public static implicit operator Quaternion[](Value value) => value._array.ConvertAll(x => (Quaternion)x).ToArray();
-        public static implicit operator List<Quaternion>(Value value) => value._array.ConvertAll(x => (Quaternion)x);
+        public static implicit operator Quaternion[](Value value) { var r = new Quaternion[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Quaternion)value._array[i]; return r; }
+        public static implicit operator List<Quaternion>(Value value) { var r = new List<Quaternion>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Quaternion)value._array[i]); return r; }
         public static implicit operator Bounds(Value value) => value.Bounds;
-        public static implicit operator Bounds[](Value value) => value._array.ConvertAll(x => (Bounds)x).ToArray();
-        public static implicit operator List<Bounds>(Value value) => value._array.ConvertAll(x => (Bounds)x);
+        public static implicit operator Bounds[](Value value) { var r = new Bounds[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Bounds)value._array[i]; return r; }
+        public static implicit operator List<Bounds>(Value value) { var r = new List<Bounds>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Bounds)value._array[i]); return r; }
         public static implicit operator Rect(Value value) => value.Rect;
-        public static implicit operator Rect[](Value value) => value._array.ConvertAll(x => (Rect)x).ToArray();
-        public static implicit operator List<Rect>(Value value) => value._array.ConvertAll(x => (Rect)x);
+        public static implicit operator Rect[](Value value) { var r = new Rect[value._array.Count]; for (int i = 0; i < r.Length; i++) r[i] = (Rect)value._array[i]; return r; }
+        public static implicit operator List<Rect>(Value value) { var r = new List<Rect>(value._array.Count); for (int i = 0; i < value._array.Count; i++) r.Add((Rect)value._array[i]); return r; }
         
         #endregion
 
         #region Writer
 
-        private void Write(StringWriter writer, bool includeTypeInfo = false)
+        private void Write(StringBuilder sb, bool includeTypeInfo = false)
         {
             if (includeTypeInfo)
             {
-                writer.Write("{");
-                writer.Write($"\"JsonType\": \"{_valueType}\", \"DataType\": \"{_dataType}\", \"Value\": ");
+                sb.Append("{\"JsonType\": \"");
+                sb.Append(_valueType);
+                sb.Append("\", \"DataType\": \"");
+                sb.Append(_dataType);
+                sb.Append("\", \"Value\": ");
             }
             switch (_valueType)
             {
                 case ValueTypes.UNDEFINED:
                 case ValueTypes.NULL:
-                    writer.Write("null");
+                    sb.Append("null");
                     break;
                 case ValueTypes.STRING:
-                    writer.Write("\"");
-                    writer.Write(SanitizeStringForJson(_string));
-                    writer.Write("\"");
+                    sb.Append('"');
+                    AppendSanitizedString(sb, _string);
+                    sb.Append('"');
                     break;
                 case ValueTypes.BOOLEAN:
-                    writer.Write(_bool ? "true" : "false");
+                    sb.Append(_bool ? "true" : "false");
                     break;
                 case ValueTypes.NUMBER:
-                    writer.Write(_number.ToString(CultureInfo.InvariantCulture));
+                    sb.Append(_number.ToString(CultureInfo.InvariantCulture));
                     break;
                 case ValueTypes.ARRAY:
-                    writer.Write("[");
-                    int arrayIndex = 0;
-                    int arrayCount = _array.Count - 1;
-                    foreach (Value item in _array)
+                    sb.Append('[');
+                    for (int i = 0; i < _array.Count; i++)
                     {
-                        item.Write(writer, includeTypeInfo);
-                        if (arrayIndex < arrayCount) writer.Write(", ");
-                        arrayIndex++;
+                        if (i > 0) sb.Append(", ");
+                        _array[i].Write(sb, includeTypeInfo);
                     }
-                    writer.Write("]");
+                    sb.Append(']');
                     break;
                 case ValueTypes.OBJECT:
-                    writer.Write("{");
-                    if (_dataType == DataTypes.CONTAINER)
+                    sb.Append('{');
+                    int idx = 0;
+                    foreach (KeyValuePair<string, Value> kvp in _container)
                     {
-                        int containerIndex = 0;
-                        int containerCount = _container.Count - 1;
-                        foreach (KeyValuePair<string, Value> kvp in _container)
-                        {
-                            writer.Write($"\"{kvp.Key}\": ");
-                            kvp.Value.Write(writer, includeTypeInfo);
-                            if (containerIndex < containerCount) writer.Write(", ");
-                            containerIndex++;
-                        }
+                        if (idx > 0) sb.Append(", ");
+                        sb.Append('"');
+                        sb.Append(kvp.Key);
+                        sb.Append("\": ");
+                        kvp.Value.Write(sb, includeTypeInfo);
+                        idx++;
                     }
-                    else
-                    {
-                        int containerIndex = 0;
-                        int containerCount = _container.Count - 1;
-                        foreach (KeyValuePair<string, Value> kvp in _container)
-                        {
-                            writer.Write($"\"{kvp.Key}\": {kvp.Value}");
-                            if (containerIndex < containerCount) writer.Write(", ");
-                            containerIndex++;
-                        }
-                    }
-                    writer.Write("}");
+                    sb.Append('}');
                     break;
                 default:
                     throw new ArgumentOutOfRangeException();
             }
-
-            if (includeTypeInfo)
-            {
-                writer.Write("}");
-            }
+            if (includeTypeInfo) sb.Append('}');
         }
         
         #endregion
         
         #region Reader
 
-        public static string SanitizeStringForJson(string s)
+        private static void AppendSanitizedString(StringBuilder sb, string s)
         {
-            if (s == null || s.Length == 0) {
-                return "";
-            }
-
-            StringBuilder sb = new StringBuilder();
+            if (s == null || s.Length == 0) return;
             for (int i = 0; i < s.Length; i += 1) {
                 char c = s[i];
                 if (c >= 0 && c <= 7 || c == 11 || c >= 14 && c <= 31 || c == 39 || c == 60 || c == 62)
@@ -870,6 +861,16 @@ namespace mixpanel
                         break;
                 }
             }
+        }
+
+        public static string SanitizeStringForJson(string s)
+        {
+            if (s == null || s.Length == 0) {
+                return "";
+            }
+
+            StringBuilder sb = new StringBuilder();
+            AppendSanitizedString(sb, s);
             return sb.ToString();
         }
         
@@ -884,7 +885,6 @@ namespace mixpanel
 
         private void SerializeList()
         {
-            if (_array == null) _array = new List<Value>(0);
             int count = _array.Count;
             _arrayData = new string[count];
             if (count <= 0) return;
@@ -896,7 +896,6 @@ namespace mixpanel
 
         private void SerializeDictionary()
         {
-            if (_container == null) _container = new Dictionary<string, Value>(0);
             int count = _container.Count;
             _containerKeys = new string[count];
             _containerValues = new string[count];
@@ -930,6 +929,7 @@ namespace mixpanel
                 JsonUtility.FromJsonOverwrite(data, item);
                 _array.Add(item);
             }
+            _arrayData = null;
         }
 
         private void DeserializeDictionary()
@@ -944,6 +944,8 @@ namespace mixpanel
                 JsonUtility.FromJsonOverwrite(_containerValues[i], item);
                 _container[_containerKeys[i]] = item;
             }
+            _containerKeys = null;
+            _containerValues = null;
         }
         #endregion
 

--- a/Mixpanel/Value.cs
+++ b/Mixpanel/Value.cs
@@ -614,84 +614,84 @@ namespace mixpanel
         #region ToJsonType
         
         public static implicit operator Value(string value) => new Value(value);
-        public static implicit operator Value(string[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<string> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(string[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<string> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(bool value) => new Value(value);
-        public static implicit operator Value(bool[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<bool> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(bool[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<bool> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(float value) => new Value((double)(decimal)value);
-        public static implicit operator Value(float[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<float> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(float[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<float> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(double value) => new Value(value);
-        public static implicit operator Value(double[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<double> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(double[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<double> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(decimal value) => new Value((double)value);
-        public static implicit operator Value(decimal[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<decimal> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(decimal[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<decimal> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(short value) => new Value(value);
-        public static implicit operator Value(short[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<short> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(short[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<short> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(int value) => new Value(value);
-        public static implicit operator Value(int[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<int> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(int[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<int> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(long value) => new Value(value);
-        public static implicit operator Value(long[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<long> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(long[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<long> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(ushort value) => new Value(value);
-        public static implicit operator Value(ushort[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<ushort> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(ushort[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<ushort> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(uint value) => new Value(value);
-        public static implicit operator Value(uint[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<uint> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(uint[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<uint> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(ulong value) => new Value(value);
-        public static implicit operator Value(ulong[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<ulong> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(ulong[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<ulong> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(sbyte value) => new Value(value);
-        public static implicit operator Value(sbyte[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<sbyte> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(sbyte[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<sbyte> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(byte value) => new Value(value);
-        public static implicit operator Value(byte[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<byte> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(byte[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<byte> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         
         public static implicit operator Value(Uri value) => new Value(value);
-        public static implicit operator Value(Uri[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Uri> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Uri[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Uri> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Guid value) => new Value(value);
-        public static implicit operator Value(Guid[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Guid> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Guid[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Guid> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(DateTime value) => new Value(value);
-        public static implicit operator Value(DateTime[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<DateTime> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(DateTime[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<DateTime> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(DateTimeOffset value) => new Value(value);
-        public static implicit operator Value(DateTimeOffset[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<DateTimeOffset> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(DateTimeOffset[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<DateTimeOffset> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(TimeSpan value) => new Value(value);
-        public static implicit operator Value(TimeSpan[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<TimeSpan> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(TimeSpan[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<TimeSpan> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Color value) => new Value(value);
-        public static implicit operator Value(Color[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Color> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Color[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Color> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Color32 value) => new Value(value);
-        public static implicit operator Value(Color32[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Color32> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Color32[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Color32> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector2 value) => new Value(value);
-        public static implicit operator Value(Vector2[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Vector2> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Vector2[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector2> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector3 value) => new Value(value);
-        public static implicit operator Value(Vector3[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Vector3> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Vector3[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector3> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Vector4 value) => new Value(value);
-        public static implicit operator Value(Vector4[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Vector4> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Vector4[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Vector4> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Quaternion value) => new Value(value);
-        public static implicit operator Value(Quaternion[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Quaternion> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Quaternion[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Quaternion> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Bounds value) => new Value(value);
-        public static implicit operator Value(Bounds[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Bounds> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Bounds[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Bounds> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         public static implicit operator Value(Rect value) => new Value(value);
-        public static implicit operator Value(Rect[] value) { var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
-        public static implicit operator Value(List<Rect> value) { var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(Rect[] value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Length); for (int i = 0; i < value.Length; i++) v._array.Add(value[i]); return v; }
+        public static implicit operator Value(List<Rect> value) { if (value == null) throw new ArgumentNullException(nameof(value)); var v = Value.Array; v._array = new List<Value>(value.Count); for (int i = 0; i < value.Count; i++) v._array.Add(value[i]); return v; }
         
         #endregion
 
@@ -824,7 +824,7 @@ namespace mixpanel
                     {
                         if (idx > 0) sb.Append(", ");
                         sb.Append('"');
-                        sb.Append(kvp.Key);
+                        AppendSanitizedString(sb, kvp.Key);
                         sb.Append("\": ");
                         kvp.Value.Write(sb, includeTypeInfo);
                         idx++;
@@ -1073,7 +1073,7 @@ namespace mixpanel
         {
             string number = NextWord(reader);
             double parsedDouble;
-            double.TryParse(number, out parsedDouble);
+            double.TryParse(number, NumberStyles.Float, CultureInfo.InvariantCulture, out parsedDouble);
             return parsedDouble;
         }
         

--- a/Mixpanel/Value.cs
+++ b/Mixpanel/Value.cs
@@ -78,8 +78,6 @@ namespace mixpanel
 
         public void OnRecycle()
         {
-            _valueType = ValueTypes.OBJECT;
-            _dataType = DataTypes.UNDEFINED;
             _string = "";
             _bool = false;
             _number = 0;
@@ -88,6 +86,17 @@ namespace mixpanel
             _containerBacking = null;
             _containerKeys = null;
             _containerValues = null;
+        }
+
+        // Full reset used by the Controller's value pool. Differs from
+        // OnRecycle by also clearing _valueType/_dataType so a pooled Value
+        // can be reused as any type without tripping the type assertions in
+        // the indexer setters.
+        internal void ResetForPool()
+        {
+            _valueType = ValueTypes.OBJECT;
+            _dataType = DataTypes.UNDEFINED;
+            OnRecycle();
         }
 
         public Value this[int index]
@@ -933,32 +942,35 @@ namespace mixpanel
         private void DeserializeList()
         {
             if (_arrayData == null) return;
-            int count = _arrayData.Length;
+            // Capture and clear the shadow array before iterating so the
+            // cleanup also applies to empty arrays (count == 0).
+            string[] data = _arrayData;
+            _arrayData = null;
+            int count = data.Length;
             _array = new List<Value>(count);
-            if (count == 0) return;
-            foreach (string data in _arrayData)
+            for (int i = 0; i < count; i++)
             {
                 Value item = new Value();
-                JsonUtility.FromJsonOverwrite(data, item);
+                JsonUtility.FromJsonOverwrite(data[i], item);
                 _array.Add(item);
             }
-            _arrayData = null;
         }
 
         private void DeserializeDictionary()
         {
             if (_containerKeys == null) return;
-            int count = _containerKeys.Length;
+            string[] keys = _containerKeys;
+            string[] values = _containerValues;
+            _containerKeys = null;
+            _containerValues = null;
+            int count = keys.Length;
             _container = new Dictionary<string, Value>(count);
-            if (count == 0) return;
             for (int i = 0; i < count; i++)
             {
                 Value item = new Value();
-                JsonUtility.FromJsonOverwrite(_containerValues[i], item);
-                _container[_containerKeys[i]] = item;
+                JsonUtility.FromJsonOverwrite(values[i], item);
+                _container[keys[i]] = item;
             }
-            _containerKeys = null;
-            _containerValues = null;
         }
         #endregion
 
@@ -1102,6 +1114,27 @@ namespace mixpanel
             return new Value(array);
         }
         
+        // The includeTypeInfo Write() path emits {"JsonType":"<ValueTypes>","DataType":"<DataTypes>","Value":...}.
+        // ParseObject must round-trip that, but a user payload (super property,
+        // event property) may legitimately contain keys named "JsonType" or
+        // "DataType". To avoid misinterpreting user data as internal metadata,
+        // require all three exact keys AND that the type strings parse as
+        // valid enum values.
+        private static bool LooksLikeInternalSerialization(Dictionary<string, Value> data)
+        {
+            if (data.Count != 3) return false;
+            if (!data.ContainsKey("JsonType") || !data.ContainsKey("DataType") || !data.ContainsKey("Value"))
+                return false;
+
+            Value jsonTypeVal = data["JsonType"];
+            Value dataTypeVal = data["DataType"];
+            if (jsonTypeVal == null || jsonTypeVal._valueType != ValueTypes.STRING) return false;
+            if (dataTypeVal == null || dataTypeVal._valueType != ValueTypes.STRING) return false;
+
+            return Enum.IsDefined(typeof(ValueTypes), jsonTypeVal._string)
+                && Enum.IsDefined(typeof(DataTypes), dataTypeVal._string);
+        }
+
         private static Value ParseObject(StringReader reader)
         {
             Dictionary<string, Value> data = new Dictionary<string, Value>();
@@ -1113,7 +1146,7 @@ namespace mixpanel
                     case Token.COMMA:
                         continue;
                     case Token.CURLY_CLOSE:
-                        if (data.ContainsKey("JsonType") && data.ContainsKey("DataType"))
+                        if (LooksLikeInternalSerialization(data))
                         {
                             return FromSerialization(data["JsonType"], data["DataType"], data["Value"]);
                         }

--- a/Mixpanel/Value.cs
+++ b/Mixpanel/Value.cs
@@ -67,6 +67,9 @@ namespace mixpanel
             set => _containerBacking = value;
         }
 
+        private const int SharedBuilderInitialCapacity = 256;
+        private const int MaxRetainedBuilderCapacity = 16 * 1024;
+
         [ThreadStatic] private static StringBuilder _sharedBuilder;
 
         public bool IsNull => _valueType == ValueTypes.NULL;
@@ -134,10 +137,20 @@ namespace mixpanel
                     return _number.ToString(CultureInfo.InvariantCulture);
                 case ValueTypes.ARRAY:
                 case ValueTypes.OBJECT:
-                    var sb = _sharedBuilder ?? (_sharedBuilder = new StringBuilder(256));
+                    var sb = _sharedBuilder;
+                    if (sb == null || sb.Capacity > MaxRetainedBuilderCapacity)
+                    {
+                        sb = new StringBuilder(SharedBuilderInitialCapacity);
+                        _sharedBuilder = sb;
+                    }
                     sb.Length = 0;
                     Write(sb);
-                    return sb.ToString();
+                    string json = sb.ToString();
+                    if (sb.Capacity > MaxRetainedBuilderCapacity)
+                    {
+                        _sharedBuilder = null;
+                    }
+                    return json;
                 default:
                     throw new ArgumentOutOfRangeException();
             }

--- a/Mixpanel/Worker.cs
+++ b/Mixpanel/Worker.cs
@@ -1,13 +1,5 @@
 using UnityEngine;
-using UnityEngine.Networking;
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Net;
-using System.Net.Http;
-using System.Web;
 
 namespace mixpanel
 {

--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ This library can be installed using the unity package manager system with git. W
 ## 2. Initialize Mixpanel
 
 You will need your project token for initializing your library. You can get your project token from [project settings](https://mixpanel.com/settings/project).
-To initialize the library, first open the unity project settings menu for Mixpanel. (Edit -> Project Settings -> Mixpanel) Then, enter your project token into the Token and Debug Token input fields within the inspector. Please note if you prefer to initialize Mixpanel manually, you can select the `Manual Initialization` in the settings and call `Mixpanel.Init()` to initialize.
+To initialize the library, first open the unity project settings menu for Mixpanel. (Edit -> Project Settings -> Mixpanel) Then, enter your project token into the Token and Debug Token input fields within the inspector.
+
+If you prefer to initialize Mixpanel manually, enable `Manual Initialization` in the settings and call `Mixpanel.Init()` during startup.
+
+If you define `MIXPANEL_DISABLE_AUTO_INIT`, the automatic `BeforeSceneLoad` initialization hook is compiled out entirely. In that configuration you must call `Mixpanel.Init()` yourself, even if `Manual Initialization` is not enabled in the settings. This is useful for projects that always initialize manually and want to avoid any automatic boot-time work.
 
 ![unity_screenshots](https://user-images.githubusercontent.com/36679208/152408022-62440f50-04c7-4ff3-b331-02d3d3122c9e.jpg)
 


### PR DESCRIPTION
### Problem

The SDK had several performance issues affecting IL2CPP build size, startup latency, and per-event memory pressure:

 - IL2CPP bloat: 104 implicit Value operators used Array.ConvertAll/List.ConvertAll, each generating per-type generic specializations in IL2CPP (~100+ extra methods). Unused LINQ extensions and dead code added further bloat.
 - Boot time: BeforeSceneLoad performed disk I/O (PlayerPrefs reads, Resources.LoadAll scan, SystemInfo queries) on every app launch, even when ManualInitialization was enabled.
 - Memory: Every new Value() eagerly allocated a 50-slot List and 5-slot Dictionary, even for simple string/number values. StringWriter created intermediate allocations on every ToString(). Serialization shadow arrays were never freed. Per-event Value wrappers were allocated and immediately GC'd.
 - Flush path: Deserialized every queued event into Value objects just to re-serialize them to JSON for the HTTP POST body.

### Changes

#### IL2CPP size reduction

 - Replace all 104 Array.ConvertAll/.ToArray() implicit operators with direct for-loops
 - Remove unused LINQ Batch<T> extension, dead PoolFillFrames/PoolFillEachFrame constants, dead InitializeAfterSceneLoad
 - Remove 25+ unused using directives across Controller, Storage, Worker, MixpanelSettings

#### Boot time

 - Add MIXPANEL_DISABLE_AUTO_INIT define, it compiles out the [RuntimeInitializeOnLoadMethod] hook entirely for zero boot cost
 - Gate eager property preloading behind #if !MIXPANEL_DISABLE_AUTO_INIT, everything lazy-loads on first use when the define is set
 - Make FindOrCreateInstance explicit with null/length checks instead of LINQ .FirstOrDefault()

#### Memory & GC pressure

 - Lazy-init collections: _array/_container backing fields are null by default; allocated only on first access via property wrappers. Simple string/number Values allocate zero collection memory.
 - Shared StringBuilder: Write() uses StringBuilder instead of StringWriter. ToString() reuses a [ThreadStatic] shared builder. New AppendSanitizedString() avoids intermediate string allocations.
 - Value pool: RentValue()/ReturnValue() with a Stack<Value> (cap 16). DoTrack rents the wrapper data Value and returns it after enqueue.
 - Serialization cleanup: Shadow arrays nulled after deserialization. OnRecycle nulls backing fields instead of clearing collections.

#### Flush path optimization

 - DequeueBatchTrackingDataRaw: Builds the JSON array payload directly as a string during dequeue via StringBuilder, avoids deserializing stored events into Value objects just to call ToString() again. Returns a StoredBatch with the pre-built payload and tracking keys for deletion.
 - NormalizeStoredPayload: Converts legacy JsonUtility format to standard JSON on-the-fly during dequeue.
 - Refactored duplicated FlushType dispatch into shared helpers (TrackingKey, TrackingIdKey, StartIndexKey, NormalizeStartIndex)
 - Off-by-one fix: newStartIndex clamped to maxIndex + 1 instead of maxIndex

#### Storage: drop JsonUtility for new data

 - New data written via Value.ToString() (clean JSON). Reads auto-detect legacy format via IsLegacySerializedValue() and fall back to JsonUtility.FromJson, old data migrates naturally as it flushes.
 - DeleteBatchTrackingData now takes StoredBatch and iterates tracking keys directly instead of deserializing Value objects to read the "id" field.

#### Backward compatibility

 - Legacy data: DeserializeStored() / NormalizeStoredPayload() detect old JsonUtility format by checking for "_valueType": prefix and fall back transparently. [Serializable] and ISerializationCallbackReceiver retained.
 - No API changes: All public methods unchanged. SanitizeStringForJson remains public.
 - Default behaviour preserved: Without MIXPANEL_DISABLE_AUTO_INIT define, boot and init behaviour is identical to before.

### Configuration

To opt in to zero-cost boot (recommended when ManualInitialization is always enabled):
```
 // Player Settings → Scripting Define Symbols
 MIXPANEL_DISABLE_AUTO_INIT
```